### PR TITLE
feat: Added liveness and readyness probes

### DIFF
--- a/charts/dependencies/templates/_helpers.tpl
+++ b/charts/dependencies/templates/_helpers.tpl
@@ -38,9 +38,10 @@ Parameters:
 {{- end }}
 
 {{- define "http-scheme" -}}
-{{- printf "http" }}
 {{- if .Values.ingress.ssl_enabled }}
 {{- printf "https" }}
+{{- else }}
+{{- printf "http" }}
 {{- end }}
 {{- end }}
 

--- a/charts/dependencies/templates/minio.yaml
+++ b/charts/dependencies/templates/minio.yaml
@@ -23,13 +23,13 @@ spec:
     - web
   {{- end }}
   routes:
-  - match: 'Host(`minio.{{ .Values.hostname }}`) || Host(`{{ .Values.hostname }}`)'
+  - match: 'Host(`minio.{{ .Values.hostname }}`)'
     kind: Rule
     services:
     - name: minio
       namespace: {{ .Release.Namespace }}
       port: 3535
-  - match: 'Host(`minio-console.{{ .Values.hostname }}`) || Host(`{{ .Values.hostname }}`)'
+  - match: 'Host(`minio-console.{{ .Values.hostname }}`)'
     kind: Rule
     services:
     - name: minio

--- a/charts/opencrvs-services/templates/_helpers.tpl
+++ b/charts/opencrvs-services/templates/_helpers.tpl
@@ -40,9 +40,10 @@ Parameters:
 {{- end }}
 
 {{- define "http-scheme" -}}
-{{- printf "http" }}
 {{- if .Values.ingress.ssl_enabled }}
 {{- printf "https" }}
+{{- else }}
+{{- printf "http" }}
 {{- end }}
 {{- end }}
 

--- a/charts/opencrvs-services/templates/auth-deployment.yaml
+++ b/charts/opencrvs-services/templates/auth-deployment.yaml
@@ -70,10 +70,18 @@ spec:
             - name: DOMAIN
               value: {{ .Values.hostname | quote }}
           {{- include "render-env-vars" (dict "service_name" "auth" "Values" .Values) }}
+          {{ include "resources-helper" (dict "service_name" "auth" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.auth.port }}
               protocol: TCP
-          {{ include "resources-helper" (dict "service_name" "auth" "Values" .Values) | indent 10 }}
+          livenessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up x
+              port: {{ .Values.auth.port }}
+          readinessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up
+              port: {{ .Values.auth.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key
@@ -81,10 +89,6 @@ spec:
             - mountPath: /secrets/private-key.pem
               name: private-key
               subPath: private-key.pem
-          readinessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up
-              port: 4040
       restartPolicy: Always
       volumes:
         - configMap:

--- a/charts/opencrvs-services/templates/client-deployment.yaml
+++ b/charts/opencrvs-services/templates/client-deployment.yaml
@@ -40,6 +40,7 @@ spec:
     spec:
       containers:
         - image: "ghcr.io/opencrvs/ocrvs-client:{{ .Values.image.tag }}"
+          name: client
           env:
             - name: CONTENT_SECURITY_POLICY_WILDCARD
               value: "*.{{ .Values.hostname }}"
@@ -47,31 +48,29 @@ spec:
               value: http://countryconfig.{{ .Release.Namespace }}.svc.cluster.local:3040
             - name: GATEWAY_URL_INTERNAL
               value: http://gateway.{{ .Release.Namespace }}.svc.cluster.local:7070
-            # CHECK: Following variables are present on Dev environment
-            # "COUNTRY_CONFIG_URL
-            # "DECLARED_DECLARATION_SEARCH_QUERY_COUNT
-            # TODO: MINIO
+            - name: COUNTRY_CONFIG_URL
+              value: {{ include "render-external-url" (dict "service_name" "countryconfig" "Values" .Values) }}
             - name: MINIO_URL
               value: {{ include "render-external-url" (dict "service_name" "minio" "Values" .Values) }}
           {{- include "render-env-vars" (dict "service_name" "client" "Values" .Values) }}
+          {{ include "resources-helper" (dict "service_name" "client" "Values" .Values) | indent 10 }}
+          ports:
+            - containerPort: {{ .Values.client.container_port }}
+              protocol: TCP
           livenessProbe:
             httpGet:
               # /manifest.json is external service proxied by nginx on countryconfig
               # pod should be restarted once countryconfig is up
               path: /manifest.json
               port: {{ .Values.client.container_port }}
-            initialDelaySeconds: 10
             periodSeconds: 30
-          
-          name: client
-          ports:
-            - containerPort: {{ .Values.client.container_port }}
-              protocol: TCP
-          {{ include "resources-helper" (dict "service_name" "client" "Values" .Values) | indent 10 }}
           readinessProbe:
             httpGet:
-              path: /ping
+              # /manifest.json is external service proxied by nginx on countryconfig
+              # pod should be restarted once countryconfig is up
+              path: /manifest.json
               port: {{ .Values.client.container_port }}
+            periodSeconds: 30
       restartPolicy: Always
 
 {{- include "service-helper" (dict "service_name" "client" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/config-deployment.yaml
+++ b/charts/opencrvs-services/templates/config-deployment.yaml
@@ -70,10 +70,11 @@ spec:
             - name: MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/application-config
           {{- include "render-env-vars" (dict "service_name" "config" "Values" .Values) }}
+          {{ include "resources-helper" (dict "service_name" "config" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.config.port }}
               protocol: TCP
-          {{ include "resources-helper" (dict "service_name" "config" "Values" .Values) | indent 10 }}
+          # TODO: Implement liveness and readiness probes
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/countryconfig-deployment.yaml
+++ b/charts/opencrvs-services/templates/countryconfig-deployment.yaml
@@ -94,10 +94,11 @@ spec:
             - name: MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/user-mgnt
           {{- include "render-env-vars" (dict "service_name" "countryconfig" "Values" .Values) }}
+          {{ include "resources-helper" (dict "service_name" "countryconfig" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.countryconfig.port }}
               protocol: TCP
-          {{ include "resources-helper" (dict "service_name" "countryconfig" "Values" .Values) | indent 10 }}
+          # TODO: Implement liveness and readiness probes
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/dashboards-deployment.yaml
+++ b/charts/opencrvs-services/templates/dashboards-deployment.yaml
@@ -37,7 +37,6 @@ spec:
     spec:
       containers:
         - name: dashboards
-          {{ include "resources-helper" (dict "service_name" "dashboards" "Values" .Values) | indent 10 }}
           image: "ghcr.io/opencrvs/ocrvs-dashboards:{{ .Values.image.tag }}"
           env:
             - name: OPENCRVS_METABASE_SITE_URL
@@ -47,9 +46,11 @@ spec:
             - name: OPENCRVS_METABASE_DB_HOST
               value: {{ .Values.mongodb_host | quote }}
           {{- include "render-env-vars" (dict "service_name" "dashboards" "Values" .Values) }}
+          {{ include "resources-helper" (dict "service_name" "dashboards" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.dashboards.port }}
               protocol: TCP
+          # TODO: Add liveness and readiness probes
       restartPolicy: Always
 
 {{- include "service-helper" (dict "service_name" "dashboards" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/documents-deployment.yaml
+++ b/charts/opencrvs-services/templates/documents-deployment.yaml
@@ -16,7 +16,8 @@ spec:
         app: documents
     spec:
       containers:
-        - name: documents
+        - image: "ghcr.io/opencrvs/ocrvs-documents:{{ .Values.image.tag }}"
+          name: documents
           env:
             - name: COUNTRY_CONFIG_URL
               value: http://countryconfig.{{ .Release.Namespace }}.svc.cluster.local:3040
@@ -34,15 +35,22 @@ spec:
             - name: MINIO_URL
               value: minio.{{ .Values.hostname }}
           {{- include "render-env-vars" (dict "service_name" "documents" "Values" .Values) }}
-          image: "ghcr.io/opencrvs/ocrvs-documents:{{ .Values.image.tag }}"
           {{ include "resources-helper" (dict "service_name" "documents" "Values" .Values) | indent 10 }}
+          ports:
+            - containerPort: {{ .Values.documents.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up x
+              port: {{ .Values.documents.port }}
+          readinessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up
+              port: {{ .Values.documents.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key
               subPath: public-key.pem
-          ports:
-            - containerPort: {{ .Values.documents.port }}
-              protocol: TCP
       restartPolicy: Always
       volumes:
         - configMap:

--- a/charts/opencrvs-services/templates/events-deployment.yaml
+++ b/charts/opencrvs-services/templates/events-deployment.yaml
@@ -63,6 +63,7 @@ spec:
           ports:
             - containerPort: {{ .Values.events.port }}
               protocol: TCP
+          # TODO: Implement liveness and readiness probes
       restartPolicy: Always
 
 {{- include "service-helper" (dict "service_name" "events" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/gateway-deployment.yaml
+++ b/charts/opencrvs-services/templates/gateway-deployment.yaml
@@ -77,10 +77,22 @@ spec:
             - name: COUNTRY_CONFIG_URL
               value: http://countryconfig.{{ .Release.Namespace }}.svc.cluster.local:3040
           {{- include "render-env-vars" (dict "service_name" "gateway" "Values" .Values) }}
+          {{ include "resources-helper" (dict "service_name" "gateway" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.gateway.port }}
               protocol: TCP
-          {{ include "resources-helper" (dict "service_name" "gateway" "Values" .Values) | indent 10 }}
+          livenessProbe:
+            initialDelaySeconds: 30
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up x
+              port: {{ .Values.gateway.port }}
+            timeoutSeconds: 5
+          readinessProbe:
+            initialDelaySeconds: 30
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up
+              port: {{ .Values.gateway.port }}
+            timeoutSeconds: 5
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/login-deployment.yaml
+++ b/charts/opencrvs-services/templates/login-deployment.yaml
@@ -39,8 +39,14 @@ spec:
     spec:
       containers:
         - name: login
-          {{ include "resources-helper" (dict "service_name" "login" "Values" .Values) | indent 10 }}
           image: "ghcr.io/opencrvs/ocrvs-login:{{ .Values.image.tag }}"
+          env:
+            - name: CONTENT_SECURITY_POLICY_WILDCARD
+              value: "*.{{ .Values.hostname }}"
+            - name: COUNTRY_CONFIG_URL_INTERNAL
+              value: http://countryconfig.{{ .Release.Namespace }}.svc.cluster.local:3040
+          {{- include "render-env-vars" (dict "service_name" "login" "Values" .Values) }}
+          {{ include "resources-helper" (dict "service_name" "login" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.login.container_port }}
               protocol: TCP
@@ -50,14 +56,12 @@ spec:
               # pod should be restarted once countryconfig is up
               path: /api/countryconfig/login-config.js
               port: {{ .Values.login.container_port }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
-          env:
-            - name: CONTENT_SECURITY_POLICY_WILDCARD
-              value: "*.{{ .Values.hostname }}"
-            - name: COUNTRY_CONFIG_URL_INTERNAL
-              value: http://countryconfig.{{ .Release.Namespace }}.svc.cluster.local:3040
-          {{- include "render-env-vars" (dict "service_name" "login" "Values" .Values) }}
+          readinessProbe:
+            httpGet:
+              # /api/countryconfig/login-config.js is external service proxied by nginx
+              # pod should be restarted once countryconfig is up
+              path: /api/countryconfig/login-config.js
+              port: {{ .Values.login.container_port }}
       restartPolicy: Always
 
 {{- include "service-helper" (dict "service_name" "login" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/login-deployment.yaml
+++ b/charts/opencrvs-services/templates/login-deployment.yaml
@@ -11,7 +11,7 @@ spec:
     - web
   {{- end }}
   routes:
-  - match: 'Host(`login.{{ .Values.hostname }}`)'
+  - match: 'Host(`login.{{ .Values.hostname }}`) || Host(`{{ .Values.hostname }}`)'
     kind: Rule
     services:
     - name: login

--- a/charts/opencrvs-services/templates/metrics-deployment.yaml
+++ b/charts/opencrvs-services/templates/metrics-deployment.yaml
@@ -48,10 +48,20 @@ spec:
             - name: MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/metrics
           {{- include "render-env-vars" (dict "service_name" "metrics" "Values" .Values) }}
+          {{ include "resources-helper" (dict "service_name" "metrics" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.metrics.port }}
               protocol: TCP
-          {{ include "resources-helper" (dict "service_name" "metrics" "Values" .Values) | indent 10 }}
+          livenessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up x
+              port: {{ .Values.metrics.port }}
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up
+              port: {{ .Values.metrics.port }}
+            timeoutSeconds: 3
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/migration-job.yaml
+++ b/charts/opencrvs-services/templates/migration-job.yaml
@@ -43,6 +43,8 @@ spec:
               value: mongodb://{{ .Values.mongodb_host }}/openhim-dev
             - name: DASHBOARD_MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/performance
+            - name: EVENTS_MONGO_URL
+              value: mongodb://{{ .Values.mongodb_host }}/events
             - name: WAIT_HOSTS
               value: "{{ .Values.mongodb_host }}:27017,{{ .Values.influxdb.host }}:{{ .Values.influxdb.port }},{{ .Values.minio.host }}:{{ .Values.minio.port }},{{ .Values.elasticsearch_host }}"
           {{- include "render-env-vars" (dict "service_name" "migration" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/notification-deployment.yaml
+++ b/charts/opencrvs-services/templates/notification-deployment.yaml
@@ -32,10 +32,19 @@ spec:
             - name: MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/notification
           {{- include "render-env-vars" (dict "service_name" "notification" "Values" .Values) }}
+          {{ include "resources-helper" (dict "service_name" "notification" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.notification.port }}
               protocol: TCP
-          {{ include "resources-helper" (dict "service_name" "notification" "Values" .Values) | indent 10 }}
+          livenessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up x
+              port: {{ .Values.notification.port }}
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up
+              port: {{ .Values.notification.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/search-deployment.yaml
+++ b/charts/opencrvs-services/templates/search-deployment.yaml
@@ -18,7 +18,6 @@ spec:
       containers:
         - name: search
           image: "ghcr.io/opencrvs/ocrvs-search:{{ .Values.image.tag }}"
-          {{ include "resources-helper" (dict "service_name" "search" "Values" .Values) | indent 10 }}
           env:
             - name: FHIR_URL
               value: {{ .Values.fhir_url | quote }}
@@ -33,9 +32,18 @@ spec:
             - name: HEARTH_MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/hearth-dev
           {{- include "render-env-vars" (dict "service_name" "search" "Values" .Values) }}
+          {{ include "resources-helper" (dict "service_name" "search" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.search.port }}
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up x
+              port: {{ .Values.search.port }}
+          readinessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up
+              port: {{ .Values.search.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/user-mgnt-deployment.yaml
+++ b/charts/opencrvs-services/templates/user-mgnt-deployment.yaml
@@ -38,10 +38,18 @@ spec:
             - name: COUNTRY_CONFIG_URL
               value: {{ include "render-external-url" (dict "service_name" "user-mgnt" "Values" .Values) }}
           {{- include "render-env-vars" (dict "service_name" "user_mgnt" "Values" .Values) }}
+          {{ include "resources-helper" (dict "service_name" "user_mgnt" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.user_mgnt.port }}
               protocol: TCP
-          {{ include "resources-helper" (dict "service_name" "user_mgnt" "Values" .Values) | indent 10 }}
+          livenessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up x
+              port: {{ .Values.user_mgnt.port }}
+          readinessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up
+              port: {{ .Values.user_mgnt.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/webhooks-deployment.yaml
+++ b/charts/opencrvs-services/templates/webhooks-deployment.yaml
@@ -62,10 +62,18 @@ spec:
             - name: MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/webhooks
           {{- include "render-env-vars" (dict "service_name" "webhooks" "Values" .Values) }}
+          {{ include "resources-helper" (dict "service_name" "webhooks" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.webhooks.port }}
               protocol: TCP
-          {{ include "resources-helper" (dict "service_name" "webhooks" "Values" .Values) | indent 10 }}
+          livenessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up x
+              port: {{ .Values.webhooks.port }}
+          readinessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up
+              port: {{ .Values.webhooks.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/workflow-deployment.yaml
+++ b/charts/opencrvs-services/templates/workflow-deployment.yaml
@@ -44,10 +44,18 @@ spec:
             - name: WEBHOOKS_URL
               value: http://webhooks.{{ .Release.Namespace }}.svc.cluster.local:2525/
           {{- include "render-env-vars" (dict "service_name" "workflow" "Values" .Values) }}
+          {{ include "resources-helper" (dict "service_name" "workflow" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.workflow.port }}
               protocol: TCP
-          {{ include "resources-helper" (dict "service_name" "workflow" "Values" .Values) | indent 10 }}
+          livenessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up x
+              port: {{ .Values.workflow.port }}
+          readinessProbe:
+            httpGet:
+              path: /ping # FIXME: not real healthz, just checking if http server is up
+              port: {{ .Values.workflow.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -1,3 +1,9 @@
+# NOTES:
+# Liveness and readiness probes defaults are here:
+# We are good to go with defaults for now
+# https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+
+
 # Elasticsearch configuration, including the hostname and port.
 # TODO: Consider defining the port as a separate variable.
 elasticsearch_host: elasticsearch.opencrvs-deps-dev.svc.cluster.local:9200
@@ -48,6 +54,7 @@ env:
   # SENTRY_DSN: https://...@o309867.ingest.sentry.io/....
 
 hpa:
+  enabled: true
   minReplicas: 1
   maxReplicas: 2
   averageUtilization: 75
@@ -62,20 +69,18 @@ resources:
 pdb:
   minAvailable: 50%
 
-
-client:
-  replicas: 1
-  port: 3000
-  container_port: 80
-
 auth:
   replicas: 1
   port: 4040
   hpa:
     maxReplicas: 10
 
-components:
+client:
   replicas: 1
+  port: 3000
+  container_port: 80
+  env:
+    DECLARED_DECLARATION_SEARCH_QUERY_COUNT: 100
 
 # `config` Microservice configuration example:
 config:

--- a/infrastructure/dev/opencrvs-services/values.yaml
+++ b/infrastructure/dev/opencrvs-services/values.yaml
@@ -15,16 +15,17 @@
 hostname: k8s.opencrvs.dev
 
 image:
-  # tag: develop
-  tag: 50b3e14
+  tag: develop
+  # tag: 50b3e14
 
 countryconfig:
   image:
     # Replace countryconfig with farajaland to test data
     name: opencrvs/ocrvs-farajaland
     # name: opencrvs/ocrvs-countryconfig
-    # tag: develop
-    tag: ec53c12
+    tag: develop
+    # Farajaland working tag: ec53c12
+    # tag: ec53c12
 
 documents:
 # Uncomment this section to add authentication for MinIO:


### PR DESCRIPTION
This PR is part of bigger changes from issue https://github.com/opencrvs/opencrvs-core/issues/9154

Goal of this PR is to supply liveness and readiness probes to kubernetes helm chart.

# Identified issues

- Gateway ping takes around 3 seconds
- Few services don't have `/ping` endpoint:
   - config
   - countryconfig
   - events
- `/ping` endpoint doesn't reflect real health of the service, E/g service might not be connected to database, but nodejs could be started.

More information on liveness and readiness probes can be found at https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes


# Testing

Application is deployed at: https://k8s.opencrvs.dev

Configuration can be checked at: https://console.cloud.google.com/kubernetes/deployment/europe-west1-b/gke-test/opencrvs-dev/auth/yaml/view?invt=AbuSDQ&project=opencrvs-on-k8s (auth service)