### PR TITLE
Initial CD implementation with kubernetes in-cluster runner

### DIFF
--- a/.github/workflows/build-and-push-runner-image.yml
+++ b/.github/workflows/build-and-push-runner-image.yml
@@ -1,0 +1,41 @@
+name: Build and Push Custom Runner Image
+
+on:
+  push:
+    branches: ["*"]
+    paths:
+      - .github/workflows/build-and-push-runner-image.yml
+      - github-runner/Dockerfile  # Trigger when Dockerfile changes
+      - github-runner/**   # Optional: if your Docker context is in a folder
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      packages: write
+    env:
+      image_path: ghcr.io/opencrvs/opencrvs-github-runner
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          COMMIT_HASH=$(echo ${{ github.sha }} | cut -c1-7)
+          echo "image_tag=${COMMIT_HASH}" >> $GITHUB_ENV
+          docker build -t ${{ env.image_path }}:${COMMIT_HASH} -f github-runner/Dockerfile github-runner/
+
+      - name: Push Docker image
+        run: |
+          docker push ${{ env.image_path }}:${{ env.image_tag }}
+          docker tag ${{ env.image_path }}:${{ env.image_tag }} ${{ env.image_path }}:latest
+          docker push ${{ env.image_path }}:latest

--- a/.github/workflows/deploy-on-gcp.yml
+++ b/.github/workflows/deploy-on-gcp.yml
@@ -1,0 +1,57 @@
+name: Deploy on GCP
+on:
+    workflow_dispatch:
+      inputs:
+        core-image-tag:
+          description: "Tag of the core image"
+          required: true
+          default: "latest"
+        countryconfig-image-tag:
+          description: "Tag of the countryconfig image"
+          required: true
+          default: "latest"
+        environment:
+          description: "Target environment"
+          required: true
+          default: "dev"
+          type: choice
+          options:
+            - dev
+            - staging
+            - prod
+    # push:
+    #     branches: ["develop"]
+jobs:
+  deploy:
+    runs-on: [self-hosted, gcp]
+    # TEMPORARY COMMENTED
+    # environment: ${{ github.event.inputs.environment }}
+
+    steps:
+      - name: Print deployment parameters
+        run: |
+          echo "Deploying core image: ${{ github.event.inputs.core-image-tag }}"
+          echo "Deploying countryconfig image: ${{ github.event.inputs.countryconfig-image-tag }}"
+          echo "Target environment: ${{ github.event.inputs.environment }}"
+      # FYI: Repository is needed only due to single file: infrastructure/dev/opencrvs-services/values.yaml
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set environment variables
+        run: |
+          export CORE_IMAGE_TAG="${{ github.event.inputs.core-image-tag }}"
+          export COUNTRYCONFIG_IMAGE_TAG="${{ github.event.inputs.countryconfig-image-tag }}"
+          export ENV="${{ github.event.inputs.environment }}"
+          echo "Environment: $ENV"
+          echo "Core Image: $CORE_IMAGE_TAG"
+          echo "Country Config Image: $COUNTRYCONFIG_IMAGE_TAG"
+
+      - name: Deploy with Helm
+        run: |
+          helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services:0.0.1 \
+            --namespace "opencrvs-${ENV}" \
+            -f infrastructure/${ENV}/opencrvs-services/values.yaml \
+            --create-namespace \
+            --set core.image.tag="$CORE_IMAGE_TAG" \
+            --set countryconfig.image.tag="$COUNTRYCONFIG_IMAGE_TAG" \
+            --set environment="$ENV"

--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -2,9 +2,10 @@ name: Release Charts
 
 on:
   push:
-    branches:
-      - develop
-
+    branches: ["*"]
+    paths:
+      - charts/**  # Trigger when any chart changes
+      - .github/workflows/publish-charts.yml  # Trigger when this workflow file changes
 jobs:
   release:
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dump.temporal.env
 *.tfstate
 *.tfstate.backup
 vars
+TODO.md

--- a/github-runner/Dockerfile
+++ b/github-runner/Dockerfile
@@ -1,0 +1,8 @@
+FROM summerwind/actions-runner
+USER root
+RUN apt-get update && apt-get install -y curl unzip gnupg
+RUN curl -LO "https://dl.k8s.io/release/v1.29.0/bin/linux/amd64/kubectl" \
+ && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+RUN cat /etc/passwd
+USER runner

--- a/github-runner/deploy-runner.sh
+++ b/github-runner/deploy-runner.sh
@@ -1,0 +1,29 @@
+# https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/quickstart-for-actions-runner-controller
+
+helm upgrade --install actions-runner-controller actions-runner-controller/actions-runner-controller \
+    --create-namespace \
+    --namespace actions-runner-system \
+    --set githubWebhookServer.enabled=false \
+    --set authSecret.create=true \
+    --set authSecret.github_token=${GITHUB_PAT}
+
+# NAMESPACE="arc-systems"
+# helm upgrade --install arc \
+#     --namespace "${NAMESPACE}" \
+#     --create-namespace \
+#     oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller
+
+# INSTALLATION_NAME="arc-runner-set"
+# NAMESPACE="arc-runners"
+# GITHUB_CONFIG_URL="https://github.com/opencrvs/infrastructure"
+# GITHUB_PAT=${GITHUB_PAT}
+# helm upgrade --install "${INSTALLATION_NAME}" \
+#     --namespace "${NAMESPACE}" \
+#     --create-namespace \
+#     --set githubConfigUrl="${GITHUB_CONFIG_URL}" \
+#     --set githubConfigSecret.github_token="${GITHUB_PAT}" \
+#     --set runnerScaleSetName="opencrvs-dev" \
+#     -f values.yaml \
+#     oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
+
+kubectl apply -f runner-deployment.yaml

--- a/github-runner/ephemeral-runner.yaml
+++ b/github-runner/ephemeral-runner.yaml
@@ -1,0 +1,16 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerSet
+metadata:
+  name: opencrvs-ephemeral
+  namespace: actions-runner-system
+spec:
+  replicas: 1
+  template:
+
+      repository: opencrvs/infrastructure
+      labels:
+        - ephemeral
+      dockerdWithinRunnerContainer: true
+      env:
+        - name: RUNNER_DEBUG
+          value: "true"

--- a/github-runner/runner-deployment.yaml
+++ b/github-runner/runner-deployment.yaml
@@ -1,0 +1,19 @@
+# runner-deployment.yaml
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: opencrvs-infra-runner
+  namespace: actions-runner-system
+spec:
+  replicas: 1
+  template:
+    spec:
+      serviceAccountName: actions-runner-controller
+      repository: opencrvs/infrastructure
+      image: ghcr.io/opencrvs/opencrvs-github-runner:latest
+      labels:
+        - opencrvs
+        - gcp
+      env:
+        - name: DOCKER_ENABLED
+          value: "true"

--- a/github-runner/values.yaml
+++ b/github-runner/values.yaml
@@ -1,0 +1,6 @@
+template:
+  spec:
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:latest
+        command: ["/home/runner/run.sh"]


### PR DESCRIPTION
In this PR we are adding following features:
- Publish helm charts to github packages
- Initial CD implementation
- Custom in cluster runner setup script (part of final goal opencrvs-bootstrap.sh)
- Build custom runner docker image (default github runner + helm + kubectl)

Tests:
- Workflow tests are located at GitHub actions
   <img width="355" alt="image" src="https://github.com/user-attachments/assets/e218783e-ce05-4d24-a880-e16c0e22de1c" />

- Packages are attached to the repository automatically: 
   <img width="361" alt="image" src="https://github.com/user-attachments/assets/0fe9b00a-bfb5-4e89-b5ee-c6fd6f262853" />
