### PR TITLE
feat: Add Mongo authentication

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -41,7 +41,7 @@ opencrvs_namespace = 'opencrvs-dev'
 # - Setup MinIO admin user and password
 # - Configure Redis users
 # - Sync passwords between dependencies and OpenCRVS services
-security_enabled = False
+security_enabled = True
 
 # If your machine is powerful feel free to change parallel updates from default 3
 # Be careful repositories like npm, yarn, pip, etc. could have rate limits
@@ -100,6 +100,6 @@ reset_environment(opencrvs_namespace, opencrvs_configuration_file)
 seed_data(opencrvs_namespace, opencrvs_configuration_file)
 
 if security_enabled:
-    copy_secrets(opencrvs_namespace, dependencies_namespace)
+    copy_secrets(dependencies_namespace, opencrvs_namespace)
 
 print("✅ Tiltfile configuration loaded successfully.")

--- a/charts/dependencies/Chart.yaml
+++ b/charts/dependencies/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrvs-dependencies-chart
 description: Dependencies required by OpenCRVS
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.8.0

--- a/charts/dependencies/files/mongodb-create-users.sh
+++ b/charts/dependencies/files/mongodb-create-users.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# OpenCRVS is also distributed under the terms of the Civil Registration
+# & Healthcare Disclaimer located at http://opencrvs.org/license.
+#
+# Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+
+# This file is run on each deployment with the sole purpose of updating
+# passwords of MongoDB users to passwords given to this service as environment varibles
+
+mongo_credentials() {
+    if [ ! -z ${MONGODB_ADMIN_USER+x} ] || [ ! -z ${MONGODB_ADMIN_PASSWORD+x} ]; then
+    echo "--username $MONGODB_ADMIN_USER --password $MONGODB_ADMIN_PASSWORD --authenticationDatabase admin";
+    else
+    echo "";
+    fi
+}
+NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+echo NAMESPACE:$NAMESPACE
+HOST="mongodb-0.mongodb.${NAMESPACE}.svc.cluster.local"
+echo "Database: $HOST"
+function checkIfUserExists {
+    local user=$1
+    local JSON="{\"user\": \"$user\"}"
+    CMD='mongo admin --host $HOST $(mongo_credentials) --quiet --eval "db.getCollection(\"system.users\").find($JSON).length() > 0 ? \"FOUND\" : \"NOT_FOUND\""'
+    eval $CMD
+}
+
+# Rotate passwords to match the ones given to this script or create new users
+echo "==============================================================="
+echo "Creating new users or updating passwords"
+echo "==============================================================="
+function update_credentials() {
+db=$1
+user=$2
+password=$3
+roles=`echo $4 | sed 's/"//g'`
+if [ -z "$roles" ]
+then
+  roles="[{ role: 'readWrite', db: '$db' }]"
+fi
+echo "db: $db, user: $user, password: $password, roles: $roles"
+
+user_exists=$(echo $(checkIfUserExists "$user"))
+if [[ $user_exists != "FOUND" ]]; then
+    echo "$user user not found"
+    mongo $(mongo_credentials) --host $HOST <<EOF
+    use $db
+    db.createUser({
+    user: '$user',
+    pwd: '$password',
+    roles: $roles
+    })
+EOF
+else
+    echo "$user user exists"
+    mongo $(mongo_credentials) --host $HOST <<EOF
+    use $db
+    db.updateUser('$user', {
+    pwd: '$password',
+    roles: $roles
+    })
+EOF
+fi
+}
+
+PREFIXES=( $(env | grep -oP "[A-Z_]+_MONGODB_USER" | sed 's/_MONGODB_USER//' | sort) )
+echo "Prefixes: ${PREFIXES[@]}"
+for prefix in ${PREFIXES[@]}
+do
+  db_var=${prefix}_MONGODB_DB
+  db=${!db_var}
+  password_var=${prefix}_MONGODB_PASSWORD
+  password=${!password_var}
+  user_var=${prefix}_MONGODB_USER
+  user=${!user_var}
+  roles_var=${prefix}_MONGODB_ROLES
+  roles=${!roles_var}
+  update_credentials $db $user $password "$roles"
+done

--- a/charts/dependencies/templates/hearth.yaml
+++ b/charts/dependencies/templates/hearth.yaml
@@ -42,7 +42,15 @@ spec:
             - name: logger__level
               value: warn
             - name: mongodb__url
+          # FIXME: If you use external mongodb, please update this part to reference correct secret
+          {{- if .Values.mongodb.use_default_credentials }}
               value: mongodb://mongodb.{{ .Release.Namespace }}.svc.cluster.local/hearth-dev
+          {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-urls
+                  key: HEARTH_MONGO_URL
+          {{- end }}
             - name: server__fhirVersion
               value: stu3
           {{- if or .Values.hearth.secrets .Values.hearth.env .Values.env }}

--- a/charts/dependencies/templates/mongo-on-update-configmap.yaml
+++ b/charts/dependencies/templates/mongo-on-update-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.mongodb.use_default_credentials }}
+apiVersion: v1
+data:
+  on-deploy.sh: |
+    {{- .Files.Get "files/mongodb-create-users.sh" | indent 8 }}
+kind: ConfigMap
+metadata:
+  labels:
+    app: mongo
+  name: mongo-on-update-script
+{{- end }}

--- a/charts/dependencies/templates/mongo-on-update.yaml
+++ b/charts/dependencies/templates/mongo-on-update.yaml
@@ -1,0 +1,83 @@
+# TODO: Move as pre-deploy hook to opencrvs-service
+# Change will allow to manage external database
+{{- if not .Values.mongodb.use_default_credentials }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "5"
+  labels:
+    app: mongo-on-deploy
+  name: mongo-on-deploy
+spec:
+  template:
+    metadata:
+      labels:
+        app: mongo-on-deploy
+    spec:
+      containers:
+        - name: mongo-on-deploy
+          command: ["/bin/bash", "/on-deploy.sh"]
+          image: "mongo:4.4"
+          env:
+            - name: MONGODB_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-admin-user
+                  key: MONGODB_ADMIN_USER
+            - name: MONGODB_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-admin-user
+                  key: MONGODB_ADMIN_PASSWORD
+          {{- range .Values.mongodb.databases }}
+            - name: {{ .prefix }}_MONGODB_DB
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-opencrvs-users
+                  key: {{ .prefix }}_MONGODB_DB
+            - name: {{ .prefix }}_MONGODB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-opencrvs-users
+                  key: {{ .prefix }}_MONGODB_USER
+            - name: {{ .prefix }}_MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-opencrvs-users
+                  key: {{ .prefix }}_MONGODB_PASSWORD
+          {{- if .roles }}
+            - name: {{ .prefix }}_MONGODB_ROLES
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-opencrvs-users
+                  key: {{ .prefix }}_MONGODB_ROLES
+          {{- end }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /on-deploy.sh
+              name: mongo-on-update-script
+              subPath: on-deploy.sh
+      volumes:
+        - name: mongo-on-update-script
+          configMap:
+            name: mongo-on-update-script
+      restartPolicy: "OnFailure"
+  {{- end }}
+  # mongo-on-update:
+  #   image: mongo:4.4
+  #   command: bash /on-deploy.sh
+  #   configs:
+
+  #       target: /on-deploy.sh
+
+  #     # If this doesn't get run successfully, both the replica set in mongo and
+  #     # the user schema remains uninitialized.
+  #     restart_policy:
+  #       condition: on-failure
+  #       delay: 10s
+  #   environment:
+  #     - REPLICAS=1
+  #     - MONGODB_ADMIN_USER=${MONGODB_ADMIN_USER}
+  #     - MONGODB_ADMIN_PASSWORD=${MONGODB_ADMIN_PASSWORD}

--- a/charts/dependencies/templates/mongo-secrets.yaml
+++ b/charts/dependencies/templates/mongo-secrets.yaml
@@ -1,0 +1,69 @@
+
+{{- if not .Values.mongodb.use_default_credentials }}
+{{/* Prevent secret mutation between helm upgrades */}}
+{{- $secret_name := "mongo-opencrvs-users" }}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secret_name }}
+{{- if not $secret }}
+
+{{- $passwords := dict }}
+{{- $mongo_db_urls := dict }}
+
+{{- range .Values.mongodb.databases }}
+  {{- $password := randAlphaNum 32 }}
+  {{- if $.Values.chart_dev_mode }}
+    {{- $password = printf "%s_password" .prefix }}
+  {{- end }}
+  {{- $db_url := printf "mongodb://%s:%s@mongodb-0.mongodb.%s.svc.cluster.local:27017/%s" .user $password $.Release.Namespace .db }}
+  {{- $_ := set $passwords (printf "%s_MONGODB_PASSWORD" .prefix) $password }}
+  {{- $_ := set $passwords (printf "%s_MONGODB_USER" .prefix) .user }}
+  {{- $_ := set $passwords (printf "%s_MONGODB_DB" .prefix) .db }}
+  {{- $_ := set $passwords (printf "%s_MONGODB_ROLES" .prefix) (.roles | quote) }}
+  {{- $_ := set $mongo_db_urls (printf "%s_MONGO_URL" .prefix) $db_url }}
+{{- end }}
+
+{{/*
+MognoDB regular users (per database)
+Secret is used to create users and assign appropriate roles
+*/}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secret_name }}
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  {{- range $key, $val := $passwords }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mongodb-urls
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  {{- range $key, $val := $mongo_db_urls }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}
+
+{{/* MognoDB Admin user (superuser) */}}
+---
+{{- $admin_user := randAlphaNum 8 | lower }}
+{{- $admin_password := randAlphaNum 16 }}
+{{- if $.Values.chart_dev_mode }}
+  {{- $admin_user = "admin" }}
+  {{- $admin_password = "password" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mongodb-admin-user
+type: Opaque
+data:
+  MONGODB_ADMIN_USER: {{ $admin_user | b64enc }}
+  MONGODB_ADMIN_PASSWORD: {{ $admin_password | b64enc }}
+{{- end }}
+{{- end }}

--- a/charts/dependencies/templates/mongo.yaml
+++ b/charts/dependencies/templates/mongo.yaml
@@ -37,8 +37,8 @@ spec:
   selector:
     matchLabels:
       app: mongodb
-  strategy:
-    type: Recreate
+  # strategy:
+  #   type: Recreate
   template:
     metadata:
       labels:
@@ -46,9 +46,18 @@ spec:
     spec:
       containers:
         - image: mongo:4.4
-          {{- if or .Values.mongodb.secrets .Values.mongodb.env .Values.env }}
+          {{- if not .Values.mongodb.use_default_credentials }}
           env:
-          {{- include "render-env-vars" (dict "service_name" "mongodb" "Values" .Values) }}
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-admin-user
+                  key: MONGODB_ADMIN_USER
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-admin-user
+                  key: MONGODB_ADMIN_PASSWORD
           {{- end }}
           name: mongodb
           ports:
@@ -58,10 +67,6 @@ spec:
             - mountPath: /data/db
               name: mongodb-data
       restartPolicy: Always
-      # volumes:
-      #   - name: mongodb-data
-      #     hostPath:
-      #       path: /data/db
       volumes:
         - name: mongodb-data
           persistentVolumeClaim:

--- a/charts/dependencies/values.yaml
+++ b/charts/dependencies/values.yaml
@@ -7,7 +7,38 @@ chart_dev_mode: true
 mongodb:
   enabled: true
   version: 4.4
-
+  use_default_credentials: true
+  databases:
+    - prefix: USER_MGNT
+      db: user-mgnt
+      user: user-mgnt
+    - prefix: HEARTH
+      db: hearth-dev
+      user: hearth
+      roles: "[{ role: 'readWrite', db: 'hearth' }, { role: 'readWrite', db: 'performance' }, { role: 'readWrite', db: 'hearth-dev' }]"
+    - prefix: CONFIG
+      db: application-config
+      user: config
+    - prefix: PERFORMANCE
+      db: performance
+      user: performance
+    - prefix: METRICS
+      db: metrics
+      user: metrics
+    - prefix: OPENHIM
+      db: openhim-dev
+      user: openhim
+      roles: "[{ role: 'readWrite', db: 'openhim' }, { role: 'readWrite', db: 'openhim-dev' }]"
+    - prefix: WEBHOOKS
+      db: webhooks
+      user: webhooks
+    - prefix: NOTIFICATION
+      db: notification
+      user: notification
+    - prefix: EVENTS
+      db: events
+      user: events
+      roles: "[{ role: 'readWrite', db: 'events' }, {role: 'read', db: 'user-mgnt'}]"
 minio:
   enabled: true
   use_default_credentials: true

--- a/charts/opencrvs-services/templates/config-deployment.yaml
+++ b/charts/opencrvs-services/templates/config-deployment.yaml
@@ -65,10 +65,12 @@ spec:
               value: http://search.{{ .Release.Namespace }}.svc.cluster.local:9090/    
             - name: USER_MANAGEMENT_URL
               value: http://user-mgnt.{{ .Release.Namespace }}.svc.cluster.local:3030/
+          {{- if .Values.mongodb_noauth }}     
             - name: HEARTH_MONGO_URL
               value: "mongodb://{{ .Values.mongodb_host }}/hearth-dev"
             - name: MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/application-config
+          {{- end }}
           {{- include "render-env-vars" (dict "service_name" "config" "Values" .Values) }}
           {{ include "resources-helper" (dict "service_name" "config" "Values" .Values) | indent 10 }}
           ports:

--- a/charts/opencrvs-services/templates/countryconfig-deployment.yaml
+++ b/charts/opencrvs-services/templates/countryconfig-deployment.yaml
@@ -89,10 +89,12 @@ spec:
               value: "http://auth.{{ .Release.Namespace }}.svc.cluster.local:4040"
             - name: CONFIRM_REGISTRATION_URL
               value: http://workflow.{{ .Release.Namespace }}.svc.cluster.local:5050/confirm/registration
+          {{- if .Values.mongodb_noauth }}
             - name: CONFIG_MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/application-config
             - name: MONGO_URL
-              value: mongodb://{{ .Values.mongodb_host }}/user-mgnt
+              value: mongodb://{{ .Values.mongodb_host }}/user-
+          {{- end }}
           {{- include "render-env-vars" (dict "service_name" "countryconfig" "Values" .Values) }}
           {{ include "resources-helper" (dict "service_name" "countryconfig" "Values" .Values) | indent 10 }}
           ports:

--- a/charts/opencrvs-services/templates/data-cleanup-job.yaml
+++ b/charts/opencrvs-services/templates/data-cleanup-job.yaml
@@ -19,9 +19,14 @@ spec:
             - |
               echo "Running mongo cleanup script..."
               DATABASES=("hearth-dev" "openhim-dev" "user-mgnt" "application-config" "metrics" "performance")
+              if [ ! -z ${MONGODB_ADMIN_USER+x} ] && [ ! -z ${MONGODB_ADMIN_PASSWORD+x} ]; then
+                AUTH="--username $MONGODB_ADMIN_USER --password $MONGODB_ADMIN_PASSWORD --authenticationDatabase admin";
+              else
+                AUTH="";
+              fi
               for DB in "${DATABASES[@]}"; do
                 echo "Dropping database: $DB"
-                mongo --host $MONGO_HOST --eval "db.getSiblingDB('$DB').dropDatabase()"
+                mongo $AUTH --host $MONGO_HOST --eval "db.getSiblingDB('$DB').dropDatabase()"
               done
               echo "Cleanup complete!"
           env:

--- a/charts/opencrvs-services/templates/data-migration-job.yaml
+++ b/charts/opencrvs-services/templates/data-migration-job.yaml
@@ -31,6 +31,7 @@ spec:
               value: {{ .Values.influxdb.port | quote }}
             - name: MINIO_HOST
               value: {{ .Values.minio.host | quote }}
+          {{- if .Values.mongodb_noauth }}
             - name: APPLICATION_CONFIG_MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/application-config
             - name: USER_MGNT_MONGO_URL
@@ -45,6 +46,7 @@ spec:
               value: mongodb://{{ .Values.mongodb_host }}/performance
             - name: EVENTS_MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/events
+          {{- end }}
             - name: WAIT_HOSTS
               value: "{{ .Values.mongodb_host }}:27017,{{ .Values.influxdb.host }}:{{ .Values.influxdb.port }},{{ .Values.minio.host }}:{{ .Values.minio.port }},{{ .Values.elasticsearch_host }}"
           {{- include "render-env-vars" (dict "service_name" "migration" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/events-deployment.yaml
+++ b/charts/opencrvs-services/templates/events-deployment.yaml
@@ -52,12 +52,14 @@ spec:
               value: "events"
             - name: USER_MANAGEMENT_URL
               value: "http://user-mgnt.{{ .Release.Namespace }}.svc.cluster.local:3030/"
+          {{- if .Values.mongodb_noauth }}
             - name: USER_MGNT_MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/user-mgnt
             - name: EVENTS_MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/events
             - name: MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/events
+          {{- end }}
           {{- include "render-env-vars" (dict "service_name" "events" "Values" .Values) }}
           {{ include "resources-helper" (dict "service_name" "events" "Values" .Values) | indent 10 }}
           ports:

--- a/charts/opencrvs-services/templates/metrics-deployment.yaml
+++ b/charts/opencrvs-services/templates/metrics-deployment.yaml
@@ -41,12 +41,14 @@ spec:
               value: {{ .Values.influxdb.host | quote }}
             - name: INFLUX_PORT
               value: {{ .Values.influxdb.port | quote }}
+          {{- if .Values.mongodb_noauth }}
             - name: DASHBOARD_MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/performance
             - name: HEARTH_MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/hearth-dev
             - name: MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/metrics
+          {{- end }}
           {{- include "render-env-vars" (dict "service_name" "metrics" "Values" .Values) }}
           {{ include "resources-helper" (dict "service_name" "metrics" "Values" .Values) | indent 10 }}
           ports:

--- a/charts/opencrvs-services/templates/notification-deployment.yaml
+++ b/charts/opencrvs-services/templates/notification-deployment.yaml
@@ -29,8 +29,10 @@ spec:
               value: http://countryconfig.{{ .Release.Namespace }}.svc.cluster.local:3040
             - name: USER_MANAGEMENT_URL
               value: http://user-mgnt.{{ .Release.Namespace }}.svc.cluster.local:3030/
+          {{- if .Values.mongodb_noauth }}
             - name: MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/notification
+          {{- end }}
           {{- include "render-env-vars" (dict "service_name" "notification" "Values" .Values) }}
           {{ include "resources-helper" (dict "service_name" "notification" "Values" .Values) | indent 10 }}
           ports:

--- a/charts/opencrvs-services/templates/scheduler-deployment.yaml
+++ b/charts/opencrvs-services/templates/scheduler-deployment.yaml
@@ -21,7 +21,9 @@ spec:
           env:
             - name: METRICS_URL
               value: http://metrics.{{ .Release.Namespace }}.svc.cluster.local:1050
+          {{- if .Values.mongodb_noauth }}
             - name: OPENHIM_MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/openhim-dev
+          {{- end }}
           {{- include "render-env-vars" (dict "service_name" "scheduler" "Values" .Values) }}
       restartPolicy: Always

--- a/charts/opencrvs-services/templates/search-deployment.yaml
+++ b/charts/opencrvs-services/templates/search-deployment.yaml
@@ -29,8 +29,10 @@ spec:
               value: {{ .Values.elasticsearch_host | quote }}
             - name: USER_MANAGEMENT_URL
               value: http://user-mgnt.{{ .Release.Namespace }}.svc.cluster.local:3030/
+          {{- if .Values.mongodb_noauth }}
             - name: HEARTH_MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/hearth-dev
+          {{- end }}
           {{- include "render-env-vars" (dict "service_name" "search" "Values" .Values) }}
           {{ include "resources-helper" (dict "service_name" "search" "Values" .Values) | indent 10 }}
           ports:

--- a/charts/opencrvs-services/templates/user-mgnt-deployment.yaml
+++ b/charts/opencrvs-services/templates/user-mgnt-deployment.yaml
@@ -33,8 +33,10 @@ spec:
               value: http://notification.{{ .Release.Namespace }}.svc.cluster.local:2020/
             - name: DOCUMENTS_URL
               value: http://documents.{{ .Release.Namespace }}.svc.cluster.local:9050
+          {{- if .Values.mongodb_noauth }}
             - name: MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/user-mgnt
+          {{- end }}
             - name: COUNTRY_CONFIG_URL
               value: {{ include "render-external-url" (dict "service_name" "user-mgnt" "Values" .Values) }}
           {{- include "render-env-vars" (dict "service_name" "user_mgnt" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/webhooks-deployment.yaml
+++ b/charts/opencrvs-services/templates/webhooks-deployment.yaml
@@ -59,8 +59,10 @@ spec:
               value: 0.0.0.0
             - name: USER_MANAGEMENT_URL
               value: http://user-mgnt.{{ .Release.Namespace }}.svc.cluster.local:3030/
+          {{- if .Values.mongodb_noauth }}
             - name: MONGO_URL
               value: mongodb://{{ .Values.mongodb_host }}/webhooks
+          {{- end }}
           {{- include "render-env-vars" (dict "service_name" "webhooks" "Values" .Values) }}
           {{ include "resources-helper" (dict "service_name" "webhooks" "Values" .Values) | indent 10 }}
           ports:

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -33,7 +33,8 @@ minio:
 redis_host: redis-0.redis.opencrvs-deps-dev.svc.cluster.local
 # MongoDB hostname configuration.
 mongodb_host: mongodb-0.mongodb.opencrvs-deps-dev.svc.cluster.local
-
+# If set to true then skipp authentication
+mongodb_noauth: true
 ###############################################################################
 # Application configuration
 ###############################################################################
@@ -158,7 +159,7 @@ dashboards:
     OPENCRVS_METABASE_ADMIN_EMAIL: user@opencrvs.org
     OPENCRVS_METABASE_ADMIN_PASSWORD: m3tabase
   resources:
-    memoryRequest: "512Mi"
+    memoryRequest: "1Gi"
     cpuRequest: "250m"
     memoryLimit: "1Gi"
     cpuLimit: "500m"

--- a/infrastructure/localhost/dependencies/values-dev-secure.yaml
+++ b/infrastructure/localhost/dependencies/values-dev-secure.yaml
@@ -13,3 +13,6 @@ minio:
 
 elasticsearch:
   use_default_credentials: false
+
+mongodb:
+  use_default_credentials: false

--- a/infrastructure/localhost/opencrvs-services/values-dev-secure.yaml
+++ b/infrastructure/localhost/opencrvs-services/values-dev-secure.yaml
@@ -33,10 +33,18 @@ env:
   LOG_LEVEL: debug 
   MINIO_BUCKET: "ocrvs"
 
+# By default authentication is disabled on mongodb container
+# In secure configuration each container should be authorized separately
+mongodb_noauth: false
+  
 # OpenCRVS core image tag:
 image:
   tag: develop
-
+config:
+  secrets:
+    mongodb-urls:
+      - HEARTH_MONGO_URL
+      - CONFIG_MONGO_URL:MONGO_URL
 documents:
   secrets:
     minio-opencrvs-users:
@@ -48,13 +56,29 @@ auth:
     redis-opencrvs-users:
       - AUTH_REDIS_PASSWORD:REDIS_PASSWORD
       - AUTH_REDIS_USERNAME:REDIS_USERNAME
-    
+user_mgnt:
+  secrets:
+    mongodb-urls:
+      - USER_MGNT_MONGO_URL:MONGO_URL
 gateway:
   secrets:
     redis-opencrvs-users:
       - GATEWAY_REDIS_PASSWORD:REDIS_PASSWORD
       - GATEWAY_REDIS_USERNAME:REDIS_USERNAME
-
+events:
+  secrets:
+    mongodb-urls:
+      - USER_MGNT_MONGO_URL
+      - EVENTS_MONGO_URL
+      - EVENTS_MONGO_URL:MONGO_URL
+notification:
+  secrets:
+    mongodb-urls:
+      - NOTIFICATION_MONGO_URL:MONGO_URL
+search:
+  secrets:
+    mongodb-urls:
+      - HEARTH_MONGO_URL
 countryconfig:
   image:
     # Replace countryconfig with farajaland to test data
@@ -63,18 +87,41 @@ countryconfig:
     # tag: develop
     # tag: ec53c12
     tag: local
-
+  secrets:
+    mongodb-urls:
+      - CONFIG_MONGO_URL
+      - USER_MGNT_MONGO_URL:MONGO_URL
+scheduler:
+  secrets:
+    mongodb-urls:
+      - OPENHIM_MONGO_URL
+metrics:
+  secrets:
+    mongodb-urls:
+      - METRICS_MONGO_URL:DASHBOARD_MONGO_URL
+      - HEARTH_MONGO_URL
+      - METRICS_MONGO_URL:MONGO_URL
 migration:
   secrets:
     minio-opencrvs-users:
       - MINIO_ACCESS_KEY
       - MINIO_SECRET_KEY
+    mongodb-urls:
+      - CONFIG_MONGO_URL:APPLICATION_CONFIG_MONGO_URL
+      - USER_MGNT_MONGO_URL
+      - PERFORMANCE_MONGO_URL
+      - HEARTH_MONGO_URL
+      - OPENHIM_MONGO_URL
+      - METRICS_MONGO_URL:DASHBOARD_MONGO_URL
+      - EVENTS_MONGO_URL
 data_cleanup:
   secrets:
     minio-opencrvs-users:
       - MINIO_ROOT_USER
       - MINIO_ROOT_PASSWORD
-
+    mongodb-admin-user:
+      - MONGODB_ADMIN_USER
+      - MONGODB_ADMIN_PASSWORD
 data_seed:
   env:
     SUPER_USER_PASSWORD: "password"
@@ -90,7 +137,8 @@ webhooks:
     redis-opencrvs-users:
       - WEBHOOKS_REDIS_PASSWORD:REDIS_PASSWORD
       - WEBHOOKS_REDIS_USERNAME:REDIS_USERNAME
-
+    mongodb-urls:
+      - WEBHOOKS_MONGO_URL:MONGO_URL
 workflow:
   secrets:
     redis-opencrvs-users:

--- a/tilt/lib.tilt
+++ b/tilt/lib.tilt
@@ -11,21 +11,21 @@ def format_reset_environment_command(opencrvs_namespace, opencrvs_configuration_
     return """
       kubectl delete job -n {0} data-cleanup;
       helm template -f {1} --set data_cleanup.enabled=true -s templates/data-cleanup-job.yaml --namespace {0} {2} | kubectl apply -n {0} -f -;
-      sleep 10;
+      sleep 30;
       kubectl logs job/data-cleanup -f --all-containers=true -n {0};
       kubectl wait --for=condition=complete job/data-cleanup -n {0} --timeout=600s;
       kubectl delete pod -n {0} -lapp=events;
-      sleep 30;
+      kubectl wait --for=condition=ready pod -n {0} -lapp=events;
       kubectl delete job -n {0} data-migration;
       helm template -f {1} -s templates/data-migration-job.yaml --namespace {0} {2} | kubectl apply -n {0} -f -;
-      sleep 10;
+      sleep 30;
       kubectl logs job/data-migration -f -n {0};
       kubectl wait --for=condition=complete job/data-migration -n {0} --timeout=600s;
       kubectl delete job -n {0} data-seed;
       kubectl delete pod -n {0} -lapp=events;
-      sleep 30;
+      kubectl wait --for=condition=complete pod -n {0} -lapp=events;
       helm template -f {1} --set data_seed.enabled=true -s templates/data-seed-job.yaml --namespace {0} {2} | kubectl apply -n {0} -f -;
-      sleep 10;
+      sleep 30;
       kubectl logs job/data-seed -f -n {0};
       kubectl wait --for=condition=complete job/data-seed -n {0} --timeout=600s;
       kubectl delete pod -n {0} -lapp=events;
@@ -54,7 +54,9 @@ def copy_secrets(dependencies_namespace, opencrvs_namespace):
     secrets_to_copy = [
         "elasticsearch-opencrvs-users",
         "redis-opencrvs-users",
-        "minio-opencrvs-users"
+        "minio-opencrvs-users",
+        "mongodb-urls",
+        "mongodb-admin-user",
     ]
     k8s_resource(
         new_name="deps-secrets",


### PR DESCRIPTION
Linked issue: https://github.com/opencrvs/opencrvs-core/issues/9205

# Initial implementation

New kubernetes job `mongo-on-deploy` was introduced:

- Passwords are generated by dependencies chart
- MongoDB URLs are generated by dependencies chart
- Passwords and URLs are stored as secrets
- By copy secrets between namespaces passwords and urls are shared to OpenCRVS helm release
- Mapping passwords to appropriate micro services using values.yaml file.

Pros:
- No dependencies in OpenCRVS helm chart all mapping is performed over values.yaml
Cons:
- Manually copy secrets between namespaces
- Kubernetes secrets needs to be created manually, In terms of third-party (managed) MongoDB

# Future work needs to be discussed
- Move mongo-on-deploy job to OpenCRVS helm chart
- Insead of mapping secrets in values.yaml, secrets could be hardcoded in helm chart

Pros:
- Less configuration from DevOps while installation
- OpenCRVS helm chart will be able to create users on third-party database
Cons:
- Managed MongoDB OpenCRVS will need to have admin credentials which are sometimes not allowed by Security policy. We need to give an option to disable  `mongo-on-deploy` job.