### PR TITLE
feat: Add mongo backup

### DIFF
--- a/charts/dependencies/README.md
+++ b/charts/dependencies/README.md
@@ -51,6 +51,9 @@ This section allows you to configure the deployment of MongoDB within your infra
 | version                  | string  | 4.4 | Specify the MongoDB Docker image version to use. See: https://hub.docker.com/_/mongo                                         |
 | use_default_credentials  | bool    | true | If true, deploys MongoDB without authentication. If false, custom databases and users are created as specified below.                                                                                                         |
 | data_storage_size | string | 1Gi | Persistent volume claim size for MongoDB data volume |
+| backup_schedule | string | `n/a` | Backup cronjob schedule, if not defined then values from `backup.schedule` is used |
+| backup_server_dir | string | `n/a` | Directory to store encrypted backup on backup server, if not defined `backup.backup_server_dir` is used |
+
 ## Postgres
 
 Postgres configuration section for Helm values.yaml

--- a/charts/dependencies/files/elasticsearch/backup.sh
+++ b/charts/dependencies/files/elasticsearch/backup.sh
@@ -119,7 +119,7 @@ if rsync -avz \
   "${ARCHIVE_PATH}.enc" "${BACKUP_USER}@${BACKUP_HOST}:${REMOTE_DIR}/"; then
   echo "[$(date +%F\ %H:%M:%S)] Encrypted backup file ${ARCHIVE_PATH}.enc transferred to backup host ${BACKUP_HOST}:${REMOTE_DIR}"
 else
-  echo "[ERROR] Failed to transfer file ${ARCHIVE_PATH}.enc to backup host ${BACKUP_HOST}:${REMOTE_DIR}" >&2
+  echo "[$(date +%F\ %H:%M:%S)] [ERROR] Failed to transfer file ${ARCHIVE_PATH}.enc to backup host ${BACKUP_HOST}:${REMOTE_DIR}" >&2
   exit 1
 fi
   

--- a/charts/dependencies/files/minio/backup.sh
+++ b/charts/dependencies/files/minio/backup.sh
@@ -74,7 +74,7 @@ if rsync -avz \
   "${ARCHIVE_PATH}.enc" "${BACKUP_USER}@${BACKUP_HOST}:${REMOTE_DIR}/"; then
   echo "[$(date +%F\ %H:%M:%S)] Encrypted backup file ${ARCHIVE_PATH}.enc transferred to backup host ${BACKUP_HOST}:${REMOTE_DIR}"
 else
-  echo "[ERROR] Failed to transfer file ${ARCHIVE_PATH}.enc to backup host ${BACKUP_HOST}:${REMOTE_DIR}" >&2
+  echo "[$(date +%F\ %H:%M:%S)] [ERROR] Failed to transfer file ${ARCHIVE_PATH}.enc to backup host ${BACKUP_HOST}:${REMOTE_DIR}" >&2
   exit 1
 fi
   

--- a/charts/dependencies/files/mongo/backup.sh
+++ b/charts/dependencies/files/mongo/backup.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# Databases backup list
+DATABASES=${DATABASES:-"hearth-dev events user-mgnt application-config metrics webhooks performance"}
+# Initial variables configuration
+# Today's date is used for filenames if LABEL is not provided
+BACKUP_DATE=$(date +%Y-%m-%d)
+# Local directory inside container
+BACKUP_DIR="/backups"
+# Remote directory on backup server
+REMOTE_DIR="${BACKUP_REMOTE_DIR:-"/home/$BACKUP_USER"}/$BACKUP_DATE"
+# Temporal archive path inside container
+ARCHIVE_PATH="/tmp/mongo_backup_${BACKUP_DATE}.tar.gz"
+# Remote directory on backup server
+REMOTE_DIR="${BACKUP_REMOTE_DIR:-"/home/$BACKUP_USER"}/$BACKUP_DATE"
+
+mkdir -p $BACKUP_DIR
+
+# Install required software to transfer backup on remote host
+rm /etc/apt/sources.list.d/mongodb-org.list
+apt-get update
+apt-get install -y openssh-client rsync
+
+create_encrypted_backup(){
+  echo "[$(date +%F\ %H:%M:%S)] Archive and Encrypt backup at $ARCHIVE_PATH"
+  # Tar/gzip all snapshot content
+  tar czf "$ARCHIVE_PATH" -C "$BACKUP_DIR" .
+
+  # Encrypt
+  openssl enc -aes-256-cbc -pbkdf2 -salt -in "$ARCHIVE_PATH" -out "${ARCHIVE_PATH}.enc" -pass env:ENCRYPT_PASS
+  rm -f "$ARCHIVE_PATH"
+  echo "[$(date +%F\ %H:%M:%S)] Backup encrypted at ${ARCHIVE_PATH}.enc"
+}
+backup(){
+  for DB in $DATABASES; do
+    echo "[$(date +%F\ %H:%M:%S)] Running backup for DB $DB"
+    mongodump --host $MONGODB_HOST \
+      --username "$MONGODB_ADMIN_USER" \
+      --password "$MONGODB_ADMIN_PASSWORD" \
+      --authenticationDatabase admin \
+      --gzip --archive=$BACKUP_DIR/$DB.gz \
+      -d $DB
+  done
+  echo "[$(date +%F\ %H:%M:%S)] Backups completed: $BACKUP_DIR/*.gz"
+}
+
+transfer_to_backup_host(){
+  echo "[$(date +%F\ %H:%M:%S)] Transfer backup to remote host"
+if rsync -avz \
+  --rsync-path="mkdir -p $REMOTE_DIR && rsync" \
+  -e "ssh -i /ssh/ssh_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
+  "${ARCHIVE_PATH}.enc" "${BACKUP_USER}@${BACKUP_HOST}:${REMOTE_DIR}/"; then
+  echo "[$(date +%F\ %H:%M:%S)] Encrypted backup file ${ARCHIVE_PATH}.enc transferred to backup host ${BACKUP_HOST}:${REMOTE_DIR}"
+else
+  echo "[$(date +%F\ %H:%M:%S)] [ERROR] Failed to transfer file ${ARCHIVE_PATH}.enc to backup host ${BACKUP_HOST}:${REMOTE_DIR}" >&2
+  exit 1
+fi
+  
+}
+
+backup
+create_encrypted_backup
+transfer_to_backup_host

--- a/charts/dependencies/templates/influxdb.yaml
+++ b/charts/dependencies/templates/influxdb.yaml
@@ -131,7 +131,7 @@ spec:
             claimName: influxdb
       {{- else if eq $storageType "host_path" }}
           hostPath:
-            path: {{ .Values.postgres.host_data_path | default "/data/influxdb" }}
+            path: {{ .Values.influxdb.host_data_path | default "/data/influxdb" }}
             type: DirectoryOrCreate
       {{- end }}
         - name: influxdb-backup
@@ -140,7 +140,7 @@ spec:
             claimName: influxdb-backup
       {{- else if eq $storageType "host_path" }}
           hostPath:
-            path: {{ .Values.postgres.host_data_path | default "/data/backup/influxdb" }}
+            path: {{ .Values.influxdb.host_data_path | default "/data/backup/influxdb" }}
             type: DirectoryOrCreate
       {{- end }}
 {{- end }}

--- a/charts/dependencies/templates/mongo-scripts-configmap.yaml
+++ b/charts/dependencies/templates/mongo-scripts-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+{{- range $path, $file := .Files.Glob "files/mongo/*" }}
+    {{ base $path }}: |
+{{ toString $file | indent 8 }}
+{{- end }}
+kind: ConfigMap
+metadata:
+  labels:
+    app: mongo
+  name: mongodb-scripts

--- a/charts/dependencies/templates/mongo.yaml
+++ b/charts/dependencies/templates/mongo.yaml
@@ -91,7 +91,78 @@ spec:
             claimName: mongodb
       {{- else if eq $storageType "host_path" }}
           hostPath:
-            path: {{ .Values.mongodb.host_data_path | default "/data/elasticsearch" }}
+            path: {{ .Values.mongodb.host_data_path | default "/data/mongo" }}
             type: DirectoryOrCreate
       {{- end }}
+{{- if .Values.backup.enabled }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mongodb-backup
+spec:
+  schedule: {{ .Values.mongodb.backup_schedule | default .Values.backup.schedule }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: mongodump
+              image: mongo:4.4
+              env:
+                - name: MONGODB_HOST
+                  value: mongodb-0.mongodb.{{ .Release.Namespace }}.svc.cluster.local:27017
+              {{- if not .Values.mongodb.use_default_credentials }}
+                - name: MONGODB_ADMIN_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.mongodb.admin_user_secret_name }}
+                      key: MONGODB_ADMIN_USER
+                - name: MONGODB_ADMIN_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.mongodb.admin_user_secret_name }}
+                      key: MONGODB_ADMIN_PASSWORD
+              {{- end }}
+                - name: ENCRYPT_PASS
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.backup.backup_encryption_secret }}
+                      key: backup_encryption_key
+                - name: BACKUP_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.backup.backup_server_secret }}
+                      key: user
+                - name: BACKUP_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.backup.backup_server_secret }}
+                      key: host
+                - name: BACKUP_REMOTE_DIR
+                  value: "{{ .Values.mongodb.backup_server_dir | default .Values.backup.backup_server_dir }}"
+              command: ["/scripts/backup.sh"]
+              volumeMounts:
+                - name: backup-ssh-key
+                  mountPath: /ssh
+                  readOnly: true
+                - mountPath: /scripts
+                  name: mongodb-scripts
+          volumes:
+            - name: backup-ssh-key
+              secret:
+                secretName: {{ .Values.backup.backup_server_secret }}
+                defaultMode: 0400
+                items:
+                  - key: ssh_key
+                    path: ssh_key
+            - name: mongodb-scripts
+              configMap:
+                name: mongodb-scripts
+                defaultMode: 0755
+            - name: crontab
+              configMap:
+                name: mongodb-backup-jobs
+{{- end }}
 {{- end }}


### PR DESCRIPTION


# Test results

```
[2025-08-22 14:21:29] Running backup for DB hearth-dev
2025-08-22T14:21:29.754+0000    writing hearth-dev.Location to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.755+0000    writing hearth-dev.changelog to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.758+0000    writing hearth-dev.Location_view_with_plain_ids to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.760+0000    done dumping hearth-dev.Location_view_with_plain_ids (0 documents)
2025-08-22T14:21:29.760+0000    writing hearth-dev.matchingQueue to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.761+0000    writing hearth-dev.user to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.762+0000    done dumping hearth-dev.changelog (39 documents)
2025-08-22T14:21:29.763+0000    writing hearth-dev.RelatedPerson to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.767+0000    done dumping hearth-dev.RelatedPerson (0 documents)
2025-08-22T14:21:29.767+0000    writing hearth-dev.Composition_history to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.785+0000    done dumping hearth-dev.Location (337 documents)
2025-08-22T14:21:29.785+0000    done dumping hearth-dev.matchingQueue (337 documents)
2025-08-22T14:21:29.785+0000    done dumping hearth-dev.user (1 document)
2025-08-22T14:21:29.785+0000    done dumping hearth-dev.Composition_history (0 documents)
2025-08-22T14:21:29.785+0000    writing hearth-dev.Encounter_history to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.786+0000    writing hearth-dev.Patient to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.786+0000    writing hearth-dev.DocumentReference to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.786+0000    writing hearth-dev.PaymentReconciliation to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.789+0000    done dumping hearth-dev.Encounter_history (0 documents)
2025-08-22T14:21:29.790+0000    writing hearth-dev.PractitionerRole to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.794+0000    done dumping hearth-dev.Patient (0 documents)
2025-08-22T14:21:29.794+0000    writing hearth-dev.PractitionerRole_history to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.797+0000    done dumping hearth-dev.DocumentReference (0 documents)
2025-08-22T14:21:29.798+0000    writing hearth-dev.Task to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.798+0000    done dumping hearth-dev.PaymentReconciliation (0 documents)
2025-08-22T14:21:29.799+0000    done dumping hearth-dev.PractitionerRole (0 documents)
2025-08-22T14:21:29.799+0000    writing hearth-dev.Composition to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.799+0000    writing hearth-dev.Observation to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.803+0000    done dumping hearth-dev.PractitionerRole_history (0 documents)
2025-08-22T14:21:29.803+0000    done dumping hearth-dev.Task (0 documents)
2025-08-22T14:21:29.803+0000    done dumping hearth-dev.Observation (0 documents)
2025-08-22T14:21:29.804+0000    writing hearth-dev.Task_history to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.804+0000    writing hearth-dev.Encounter to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.804+0000    writing hearth-dev.Practitioner to archive '/backups/hearth-dev.gz'
2025-08-22T14:21:29.809+0000    done dumping hearth-dev.Encounter (0 documents)
2025-08-22T14:21:29.809+0000    done dumping hearth-dev.Composition (0 documents)
2025-08-22T14:21:29.809+0000    done dumping hearth-dev.Practitioner (0 documents)
2025-08-22T14:21:29.810+0000    done dumping hearth-dev.Task_history (0 documents)
[2025-08-22 14:21:29] Running backup for DB events
[2025-08-22 14:21:29] Running backup for DB user-mgnt
2025-08-22T14:21:29.871+0000    writing user-mgnt.systemroles to archive '/backups/user-mgnt.gz'
2025-08-22T14:21:29.872+0000    writing user-mgnt.systems to archive '/backups/user-mgnt.gz'
2025-08-22T14:21:29.874+0000    writing user-mgnt.users to archive '/backups/user-mgnt.gz'
2025-08-22T14:21:29.876+0000    done dumping user-mgnt.systems (0 documents)
2025-08-22T14:21:29.876+0000    done dumping user-mgnt.systemroles (7 documents)
2025-08-22T14:21:29.877+0000    done dumping user-mgnt.users (1 document)
2025-08-22T14:21:29.877+0000    writing user-mgnt.changelog to archive '/backups/user-mgnt.gz'
2025-08-22T14:21:29.884+0000    done dumping user-mgnt.changelog (12 documents)
[2025-08-22 14:21:29] Running backup for DB application-config
2025-08-22T14:21:29.913+0000    writing application-config.formversions to archive '/backups/application-config.gz'
2025-08-22T14:21:29.917+0000    done dumping application-config.formversions (0 documents)
2025-08-22T14:21:29.918+0000    writing application-config.changelog to archive '/backups/application-config.gz'
2025-08-22T14:21:29.922+0000    done dumping application-config.changelog (10 documents)
[2025-08-22 14:21:29] Running backup for DB metrics
2025-08-22T14:21:29.952+0000    writing metrics.changelog to archive '/backups/metrics.gz'
2025-08-22T14:21:29.953+0000    writing metrics.corrections to archive '/backups/metrics.gz'
2025-08-22T14:21:29.959+0000    writing metrics.vsexports to archive '/backups/metrics.gz'
2025-08-22T14:21:29.961+0000    done dumping metrics.corrections (0 documents)
2025-08-22T14:21:29.961+0000    done dumping metrics.vsexports (0 documents)
2025-08-22T14:21:29.961+0000    done dumping metrics.changelog (1 document)
[2025-08-22 14:21:29] Running backup for DB webhooks
2025-08-22T14:21:30.000+0000    writing webhooks.webhooks to archive '/backups/webhooks.gz'
2025-08-22T14:21:30.003+0000    done dumping webhooks.webhooks (0 documents)
[2025-08-22 14:21:30] Running backup for DB performance
2025-08-22T14:21:30.034+0000    writing performance.corrections to archive '/backups/performance.gz'
2025-08-22T14:21:30.036+0000    writing performance.registrations to archive '/backups/performance.gz'
2025-08-22T14:21:30.039+0000    done dumping performance.corrections (0 documents)
2025-08-22T14:21:30.040+0000    writing performance.populationEstimatesPerDay to archive '/backups/performance.gz'
2025-08-22T14:21:30.040+0000    done dumping performance.registrations (0 documents)
2025-08-22T14:21:30.043+0000    done dumping performance.populationEstimatesPerDay (0 documents)
[2025-08-22 14:21:30] Backups completed: /backups/*.gz
[2025-08-22 14:21:30] Archive and Encrypt backup at /tmp/mongo_backup_2025-08-22.tar.gz
[2025-08-22 14:21:30] Backup encrypted at /tmp/mongo_backup_2025-08-22.tar.gz.enc
[2025-08-22 14:21:30] Transfer backup to remote host
Warning: Permanently added '10.2.1.4' (ED25519) to the list of known hosts.
sending incremental file list
mongo_backup_2025-08-22.tar.gz.enc

sent 75,708 bytes  received 35 bytes  151,486.00 bytes/sec
total size is 75,552  speedup is 1.00
[2025-08-22 14:21:30] Encrypted backup file /tmp/mongo_backup_2025-08-22.tar.gz.enc transferred to backup host 10.2.1.4:/home/backup/demo/2025-08-22
```