### PR TITLE
feat: Add minio restore

### DIFF
--- a/charts/dependencies/README.md
+++ b/charts/dependencies/README.md
@@ -299,3 +299,38 @@ Recommended way to create `backup-encryption-secret` secret:
 kubectl create secret backup-encryption-secret
     --from-literal=backup_encryption_key=your-encryption-key
 ```
+
+## Restore configuration
+
+Dependencies chart has built-in restore tool for it's internal components. Tools downloads backup files from external backup server over ssh and does restore.
+
+Reference available options:
+
+| Parameter                | Type    | Default | Description                                   |
+|-|-|-|-|
+| enabled | bool | `false` | Enable or disable backup |
+| backup_server_secret | string | `backup-server-ssh-credentials` | Secret name with credentials for backup server |
+| backup_server_dir | string | `n/a` | Backup server remote directory |
+| backup_encryption_secret | string | `backup-encryption-secret` | Secret to store backup encryption key |
+
+
+Backup server connection properties needs to be stored as a kubernetes secret, secret needs to be created before enabling backup:
+- `ssh_key`, ssh private key for remote login to backup server, key should be create on backup server and private part stored in secure place
+- `user`, ssh username to login on backup server, user should have read/write access to backup folder, we strongly recommend don't enable `sudo` or other way of admin access.
+- `host`, backup server IP address or hostname.
+
+Recommended way to create `backup-server-ssh-credentials` secret:
+```
+kubectl create secret backup-server-ssh-credentials
+    --from-literal=user=your-ssh-username \
+    --from-literal=host=your.ssh.host.com \
+    --from-file=ssh_key=backup_id_rsa
+```
+
+If you are using GitHub workflow from OpenCRVS, secret will be created automatically in `opencrvs-deps-<your environment>` namespace.
+
+Recommended way to create `restore-encryption-secret` secret:
+```
+kubectl create secret restore-encryption-secret
+    --from-literal=restore_encryption_key=your-encryption-key
+```

--- a/charts/dependencies/README.md
+++ b/charts/dependencies/README.md
@@ -302,6 +302,8 @@ kubectl create secret backup-encryption-secret
 
 ## Restore configuration
 
+> NOTE: CHAPTER IS IN PROGRESS
+
 Dependencies chart has built-in restore tool for it's internal components. Tools downloads backup files from external backup server over ssh and does restore.
 
 Reference available options:

--- a/charts/dependencies/TODO.md
+++ b/charts/dependencies/TODO.md
@@ -1,2 +1,5 @@
 Open Questions:
 - Should we build dedicated helm chart for Monitoring?
+- Document restore feature
+- Move MinIO restore to cronjob
+- Document prioroty class

--- a/charts/dependencies/files/minio/cleanup.sh
+++ b/charts/dependencies/files/minio/cleanup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# OpenCRVS is also distributed under the terms of the Civil Registration
+# & Healthcare Disclaimer located at http://opencrvs.org/license.
+#
+# Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+
+apk add --no-cache minio-client
+MINIO_ALIAS=local-cleanup
+
+mcli alias set $MINIO_ALIAS 
+http://minio:3535 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD
+
+# Figure out buckets to back up
+if [ -z "$BUCKETS" ]; then
+# All buckets
+BUCKETS=$(mcli ls --json $MINIO_ALIAS | jq -r .key | sed 's:/$::')
+fi
+
+echo "Cleanup MinIO buckets: $BUCKETS"
+for bucket in $BUCKETS; do
+  echo "Backing up bucket: $bucket"
+  mcli rm --recursive --force $MINIO_ALIAS/$bucket
+  mcli rb $MINIO_ALIAS/$bucket
+  [ "${make_bucket:-true}" == 'true' ] && mcli mb $MINIO_ALIAS/$bucket
+done

--- a/charts/dependencies/files/minio/restore.sh
+++ b/charts/dependencies/files/minio/restore.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# OpenCRVS is also distributed under the terms of the Civil Registration
+# & Healthcare Disclaimer located at http://opencrvs.org/license.
+#
+# Copyright (C) The OpenCRVS Authors
+
+set -e
+
+# Initial configuration
+RESTORE_DATE=${RESTORE_DATE:-$(date -d "yesterday" +%Y-%m-%d)}
+# Mount directory to restore into (typically /data)
+RESTORE_DIR="/data"
+# Temporary work directory
+WORK_PATH="/tmp/minio-restore"
+mkdir -p "$WORK_PATH"
+# Path for decrypted archive
+ARCHIVE_NAME="minio_backup_${RESTORE_DATE}.tar.gz"
+ARCHIVE_PATH="/tmp/$ARCHIVE_NAME"
+# Password for decryption
+ENCRYPT_PASS=${ENCRYPT_PASS:?Must provide ENCRYPT_PASS}
+# Remote directory on backup server
+REMOTE_DIR="${BACKUP_REMOTE_DIR:-"/home/$BACKUP_USER"}/$RESTORE_DATE"
+# Default is filesystem restore, can be "mirror"
+RESTORE_MODE=${RESTORE_MODE:-"fs"}
+
+# Install necessary tools (if running in an Alpine-based container)
+apk add --no-cache bash curl openssl openssh jq rsync minio-client
+
+echo "[$(date +%F\ %H:%M:%S)] Starting MinIO restore operation"
+
+# Step 1. Decrypt backup
+decrypt_backup() {
+  echo "[$(date +%F\ %H:%M:%S)] Decrypting backup file"
+  openssl enc -d -aes-256-cbc -pbkdf2 -salt -in "${ARCHIVE_PATH}.enc" -out "$ARCHIVE_PATH" -pass env:ENCRYPT_PASS
+  echo "[$(date +%F\ %H:%M:%S)] Decrypted archive at $ARCHIVE_PATH"
+}
+
+# Step 2. Restore files from filesystem backup
+restore_fs() {
+  echo "[$(date +%F\ %H:%M:%S)] Restoring MinIO data using filesystem method"
+  rm -rf "${RESTORE_DIR:?}"/*  # Clean current contents!
+  tar -zxvf "$ARCHIVE_PATH" -C "$RESTORE_DIR"
+  echo "[$(date +%F\ %H:%M:%S)] Restore of $RESTORE_DIR complete"
+}
+
+# Step 2 (alternative). Restore using MinIO mirror (bucket by bucket)
+restore_mirror() {
+  MINIO_ALIAS=local-restore
+  mcli alias set $MINIO_ALIAS http://minio:3535 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD
+
+  echo "[$(date +%F\ %H:%M:%S)] Extracting archive to $WORK_PATH"
+  mkdir -p "$WORK_PATH"
+  tar -zxvf "$ARCHIVE_PATH" -C "$WORK_PATH"
+
+  # Restore each bucket
+  for bucket_dir in "$WORK_PATH"/*; do
+    bucket=$(basename "$bucket_dir")
+    echo "[$(date +%F\ %H:%M:%S)] Restoring bucket: $bucket"
+    # Make sure bucket exists
+    mcli mb --ignore-existing $MINIO_ALIAS/"$bucket"
+    # Mirror bucket data back
+    mcli mirror --overwrite "$bucket_dir" $MINIO_ALIAS/"$bucket"
+  done
+
+  echo "[$(date +%F\ %H:%M:%S)] MinIO mirror restore complete"
+}
+
+
+transfer_from_backup_host(){
+  echo "[$(date +%F\ %H:%M:%S)] Transfer backup from remote host"
+if rsync -avz \
+  -e "ssh -i /ssh/ssh_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
+  "${BACKUP_USER}@${BACKUP_HOST}:${REMOTE_DIR}/${ARCHIVE_NAME}.enc" "${ARCHIVE_PATH}.enc"; then
+  echo "[$(date +%F\ %H:%M:%S)] Encrypted backup file ${ARCHIVE_PATH}.enc transferred from backup host ${BACKUP_HOST}:${REMOTE_DIR}"
+else
+  echo "[$(date +%F\ %H:%M:%S)] [ERROR] Failed to transfer file ${ARCHIVE_PATH}.enc from backup host ${BACKUP_HOST}:${REMOTE_DIR}" >&2
+  exit 1
+fi
+  
+}
+
+# Cleanup minio before restore
+/scripts/cleanup.sh
+
+transfer_from_backup_host
+
+decrypt_backup
+
+if [ "$RESTORE_MODE" == "fs" ]; then
+  restore_fs
+elif [ "$RESTORE_MODE" == "mirror" ]; then
+  restore_mirror
+else
+  echo "[$(date +%F\ %H:%M:%S)] [ERROR] Unknown RESTORE_MODE: $RESTORE_MODE" >&2
+  exit 1
+fi
+
+echo "[$(date +%F\ %H:%M:%S)] MinIO restore process completed successfully"

--- a/charts/dependencies/templates/asserts.yaml
+++ b/charts/dependencies/templates/asserts.yaml
@@ -4,3 +4,6 @@
 {{- if not .Values.hostname }}
 {{- fail "Invalid configuration: hostname value is not defined, please check values.yaml and (or) GitHub environment DOMAIN variable" }}
 {{- end }}
+{{- if eq .Values.restore.backup_server_dir .Values.backup.backup_server_dir }}
+{{- fail "Invalid configuration: backup and restore 'backup_server_dir' is the same, please check values.yaml and (or) GitHub environment. Values should differ to avoid backup corruption." }}
+{{- end }}

--- a/charts/dependencies/templates/data-cleanup-job.yaml
+++ b/charts/dependencies/templates/data-cleanup-job.yaml
@@ -1,0 +1,191 @@
+{{- if or .Values.data_cleanup.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: data-cleanup
+  name: data-cleanup
+spec:
+  template:
+    metadata:
+      labels:
+        app: data-cleanup
+    spec:
+      containers:
+      {{- if .Values.mongodb.enabled }}
+        - name: cleanup-mongo
+          image: "mongo:4.4"
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              echo "Running mongo cleanup script..."
+              DATABASES=(
+                {{- range $.Values.mongodb.databases }}
+                  {{ .db }}
+                {{- end }}
+              )
+              if [ ! -z ${MONGODB_ADMIN_USER+x} ] && [ ! -z ${MONGODB_ADMIN_PASSWORD+x} ]; then
+                AUTH="--username $MONGODB_ADMIN_USER --password $MONGODB_ADMIN_PASSWORD --authenticationDatabase admin";
+              else
+                AUTH="";
+              fi
+              for DB in "${DATABASES[@]}"; do
+                echo "Dropping database: $DB"
+                mongo $AUTH --host $MONGO_HOST --eval "db.getSiblingDB('$DB').dropDatabase()"
+              done
+              echo "Cleanup complete!"
+          env:
+            - name: MONGO_HOST
+              value: mongodb-0.mongodb.{{ .Release.Namespace }}.svc.cluster.local
+          {{- if not .Values.mongodb.use_default_credentials }}
+            - name: MONGODB_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  key: MONGODB_ADMIN_USER
+                  name: {{ .Values.mongodb.admin_user_secret_name }}
+            - name: MONGODB_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: MONGODB_ADMIN_PASSWORD
+                  name: {{ .Values.mongodb.admin_user_secret_name }}
+          {{- end }}
+          {{- include "render-env-vars" (dict "service_name" "mongodb" "Values" .Values) }}
+      {{- end }}
+      {{- if .Values.postgres.enabled }}
+        - name: cleanup-postgres
+          image: postgres:17
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              echo "🔁 Dropping database '${POSTGRES_DB}' and roles..."
+              psql -h $POSTGRES_HOST -U "$POSTGRES_USER" -d postgres -v ON_ERROR_STOP=1 <<EOF
+              SELECT pg_terminate_backend(pid)
+              FROM pg_stat_activity
+              WHERE datname = '$POSTGRES_DB' AND pid <> pg_backend_pid();
+
+              DROP DATABASE IF EXISTS "$POSTGRES_DB";
+
+              DROP ROLE IF EXISTS "$EVENTS_MIGRATOR_ROLE";
+              DROP ROLE IF EXISTS "$EVENTS_APP_ROLE";
+              EOF
+          env:
+            - name: POSTGRES_HOST
+              value: postgres-0.postgres.{{ .Release.Namespace }}.svc.cluster.local
+          # FIXME: Double check property name "managed"
+          {{- if .Values.postgres.use_default_credentials }}
+            - name: PGPASSWORD
+              value: postgres
+            - name: POSTGRES_USER
+              value: postgres
+          {{- else }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.admin_user_secret_name }}
+                  key: POSTGRES_USER
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.admin_user_secret_name }}
+                  key: POSTGRES_PASSWORD
+          {{- end }}
+            # FIXME: Add parameters to DB names
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.events_db | replace "-" "_" }}
+            - name: EVENTS_APP_ROLE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.users_secret }}
+                  key: EVENTS_APP_POSTGRES_USER
+            - name: EVENTS_MIGRATOR_ROLE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.users_secret }}
+                  key: EVENTS_MIGRATOR_POSTGRES_USER
+      {{- end }}
+      {{- if .Values.minio.enabled }}
+        - name: cleanup-minio
+          image: "minio/mc"
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              MINIO_BUCKET=${MINIO_BUCKET:-ocrvs}
+              echo "Running mongo cleanup script..."
+              mc alias set myminio http://$MINIO_HOST:$MINIO_PORT ${MINIO_ROOT_USER:-minioadmin} ${MINIO_ROOT_PASSWORD:-minioadmin}
+              mc rm --recursive --force myminio/$MINIO_BUCKET
+              mc rb myminio/$MINIO_BUCKET
+              [ "${make_bucket:-true}" == 'true' ] && mc mb myminio/$MINIO_BUCKET
+              echo "Cleanup complete!"
+          env:
+            - name: MINIO_HOST
+              value: minio-0.minio.{{ .Release.Namespace }}.svc.cluster.local
+            - name: MINIO_PORT
+              value: "3535"
+          {{- if not .Values.minio.use_default_credentials }}
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  key: MINIO_ROOT_USER
+                  name: {{ .Values.minio.users_secret }}
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: MINIO_ROOT_PASSWORD
+                  name: {{ .Values.minio.users_secret }}
+          {{- end }}
+          {{- include "render-env-vars" (dict "service_name" "minio" "Values" .Values) }}
+      {{- end }}
+      {{- if .Values.elasticsearch.enabled }}
+        - name: cleanup-elasticsearch
+          image: "appropriate/curl"
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              approved_words="${ES_INDEX_PREFIX:-events}_ ${ELASTICSEARCH_INDEX_NAME:-ocrvs}-"
+              indices=$(curl -sS -XGET http://$ELASTICSEARCH_HOST/_cat/indices?h=index)
+              echo "Running elasticsearch cleanup script..."
+              echo "--------------------------"
+              echo "🧹 cleanup for indices: $approved_words from $indices"
+              echo "--------------------------"
+              for index in $indices; do
+                for approved in $approved_words; do
+                  case "$index" in
+                    "$approved"*) 
+                      echo "Delete index $index..."
+                      curl -sS -XDELETE "http://$ELASTICSEARCH_HOST/$index"
+                      break
+                      ;;
+                  esac
+                done
+              done
+          env:
+            - name: ELASTICSEARCH_HOST
+              value: "elasticsearch-0.elasticsearch.{{ .Release.Namespace }}.svc.cluster.local"
+          {{- if not .Values.elasticsearch.use_default_credentials }}
+            - name: ELASTICSEARCH_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: SEARCH_ELASTIC_HOST
+                  name: {{ .Values.elasticsearch.urls_secret }}
+          {{- end }}
+          {{- include "render-env-vars" (dict "service_name" "data_cleanup" "Values" .Values) }}
+      {{- end }}
+      {{- if .Values.influxdb.enabled }}
+        - name: cleanup-influxdb
+          image: "appropriate/curl"
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Running elasticsearch cleanup script..."
+              curl -X POST http://$HOST:$PORT/query?db=$DB --data-urlencode "q=DROP SERIES FROM /.*/"
+          env:
+            - name: HOST
+              value: "influxdb-0.influxdb.{{ .Release.Namespace }}.svc.cluster.local"
+            - name: PORT
+              value: "8088"
+            - name: DB
+              value: {{ .Values.influxdb.db }}
+          {{- include "render-env-vars" (dict "service_name" "data_cleanup" "Values" .Values) }}
+      {{- end }}
+      restartPolicy: "OnFailure"
+{{- end }}

--- a/charts/dependencies/templates/elasticsearch.yaml
+++ b/charts/dependencies/templates/elasticsearch.yaml
@@ -78,6 +78,7 @@ spec:
       labels:
         app: elasticsearch
     spec:
+      priorityClassName: datastore-high-priority
     {{- $node_selector := default .Values.node_selector .Values.elasticsearch.node_selector }}
     {{- if $node_selector }}
       affinity:

--- a/charts/dependencies/templates/influxdb.yaml
+++ b/charts/dependencies/templates/influxdb.yaml
@@ -85,6 +85,7 @@ spec:
       labels:
         app: influxdb
     spec:
+      priorityClassName: datastore-high-priority
     {{- $node_selector := default .Values.node_selector .Values.influxdb.node_selector }}
     {{- if $node_selector }}
       affinity:

--- a/charts/dependencies/templates/minio-scripts-configmap.yaml
+++ b/charts/dependencies/templates/minio-scripts-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.backup.enabled .Values.restore.enabled .Values.data_cleanup.enabled }}
 apiVersion: v1
 data:
 {{- range $path, $file := .Files.Glob "files/minio/*" }}
@@ -9,3 +10,4 @@ metadata:
   labels:
     app: minio
   name: minio-scripts
+{{- end }}

--- a/charts/dependencies/templates/minio.yaml
+++ b/charts/dependencies/templates/minio.yaml
@@ -70,10 +70,20 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: minio-backup-jobs
+  name: minio-backup-cronjobs
 data:
   root: |
     {{ .Values.minio.backup_schedule | default .Values.backup.schedule }} /scripts/backup.sh >> /proc/1/fd/1 2>&1
+{{- end }}
+{{- if .Values.restore.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: minio-restore-cronjobs
+data:
+  root: |
+    {{ .Values.minio.restore_schedule | default .Values.restore.schedule }} /scripts/backup.sh >> /proc/1/fd/1 2>&1
 {{- end }}
 
 ---
@@ -107,7 +117,7 @@ spec:
                 values:
                 - {{ $v }}
             {{- end }}
-      {{- end }}
+    {{- end }}
       containers:
         - args:
             - server
@@ -146,8 +156,11 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: minio
+    {{- if or .Values.backup.enabled .Values.restore.enabled }}
+      initContainers:
       {{- if .Values.backup.enabled }}
         - name: backup
+          restartPolicy: Always
           command: ["crond", "-f", "-L", "/var/log/cron.log"]
           image: "bash"
           env:
@@ -193,6 +206,57 @@ spec:
             - name: crontab
               mountPath: /etc/crontabs
       {{- end }}
+      {{- if .Values.restore.enabled }}
+        - name: restore
+          restartPolicy: Always
+          command: ["crond", "-f", "-L", "/var/log/cron.log"]
+          image: "bash"
+          env:
+            - name: RESTORE_MODE
+              value: "mirror"
+            - name: RESTORE_DATE
+              value: {{ .Values.restore.date }}
+          {{- if not .Values.minio.use_default_credentials }}
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio-opencrvs-users
+                  key: MINIO_ROOT_USER
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-opencrvs-users
+                  key: MINIO_ROOT_PASSWORD
+          {{- end }}
+            - name: ENCRYPT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.restore.backup_encryption_secret }}
+                  key: restore_encryption_key
+            - name: BACKUP_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.restore.backup_server_secret }}
+                  key: user
+            - name: BACKUP_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.restore.backup_server_secret }}
+                  key: host
+            - name: BACKUP_REMOTE_DIR
+              value: "{{ .Values.minio.backup_server_dir | default .Values.restore.backup_server_dir }}"
+          volumeMounts:
+            - name: backup-ssh-key
+              mountPath: /ssh
+              readOnly: true
+            - mountPath: /data
+              name: minio
+            - mountPath: /scripts
+              name: minio-scripts
+            - name: crontab
+              mountPath: /etc/crontabs
+      {{- end }}
+    {{- end }}
       restartPolicy: Always
       volumes:
         - name: minio
@@ -212,12 +276,26 @@ spec:
             items:
               - key: ssh_key
                 path: ssh_key
+        - name: crontab
+          configMap:
+            name: minio-backup-cronjobs
+      {{- end }}
+      {{- if .Values.restore.enabled }}
+        - name: restore-ssh-key
+          secret:
+            secretName: {{ .Values.restore.backup_server_secret }}
+            defaultMode: 0400
+            items:
+              - key: ssh_key
+                path: ssh_key
+        - name: crontab
+          configMap:
+            name: minio-restore-cronjobs
+      {{- end }}
+      {{- if or .Values.backup.enabled .Values.restore.enabled }}
         - name: minio-scripts
           configMap:
             name: minio-scripts
             defaultMode: 0755
-        - name: crontab
-          configMap:
-            name: minio-backup-jobs
       {{- end }}
 {{- end }}

--- a/charts/dependencies/templates/minio.yaml
+++ b/charts/dependencies/templates/minio.yaml
@@ -104,6 +104,7 @@ spec:
       labels:
         app: minio
     spec:
+      priorityClassName: datastore-high-priority
     {{- $node_selector := default .Values.node_selector .Values.minio.node_selector }}
     {{- if $node_selector }}
       affinity:

--- a/charts/dependencies/templates/mongo.yaml
+++ b/charts/dependencies/templates/mongo.yaml
@@ -47,6 +47,7 @@ spec:
       labels:
         app: mongodb
     spec:
+      priorityClassName: datastore-high-priority
     {{- $node_selector := default .Values.node_selector .Values.mongodb.node_selector }}
     {{- if $node_selector }}
       affinity:

--- a/charts/dependencies/templates/postgres.yaml
+++ b/charts/dependencies/templates/postgres.yaml
@@ -46,6 +46,7 @@ spec:
       labels:
         app: postgres
     spec:
+      priorityClassName: datastore-high-priority
     {{- $node_selector := default .Values.node_selector .Values.postgres.node_selector }}
     {{- if $node_selector }}
       affinity:

--- a/charts/dependencies/templates/priority-class.yaml
+++ b/charts/dependencies/templates/priority-class.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: datastore-high-priority
+value: 1000000
+globalDefault: false
+description: "High priority for Datastore pods"

--- a/charts/dependencies/values.yaml
+++ b/charts/dependencies/values.yaml
@@ -117,5 +117,21 @@ backup:
   # - host, hostname / IP of backup server
   # - ssh_key, ssh key for passwordless connection
   backup_server_secret: backup-server-ssh-credentials
-  backup_server_dir: /home/backup/demo
+  backup_server_dir: /home/backup/demo-staging
   backup_encryption_secret: backup-encryption-secret
+
+# Backup configuration
+restore:
+  enabled: false
+  # Schedule job
+  schedule: "0 0 * * *"
+  # Secret to store backup server connection configuration:
+  # - user, backup server username
+  # - host, hostname / IP of backup server
+  # - ssh_key, ssh key for passwordless connection
+  backup_server_secret: backup-server-ssh-credentials
+  backup_server_dir: /home/backup/demo
+  backup_encryption_secret: restore-encryption-secret
+
+data_cleanup:
+  enabled: false

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -363,13 +363,3 @@ data_seed:
   env:
     SUPER_USER_PASSWORD: "password"
     ACTIVATE_USERS: "true"
-
-# TODO: Implement this job
-data_backup:
-  enabled: false
-  schedule: "0 0 * * *"
-
-# TODO: Implement this job
-data_restore:
-  enabled: false
-  schedule: "0 0 * * *"

--- a/examples/stg/README.md
+++ b/examples/stg/README.md
@@ -1,0 +1,223 @@
+
+# General information
+
+This example shows how to deploy OpenCRVS with Farajaland data on multi-node kubernetes cluster. OpenCRVS can be deployed manually or using GitHub Action Workflows.
+
+# Information about deployment package
+
+Following components are included into deployment:
+- Traefik v3.4.3, official helm chart is used (traefik-36.3.0)
+- Datastores, see OpenCRVS dependencies helm chart for exact versions:
+  - MongoDB
+  - Postgres
+  - Elasticsearch
+  - Redis
+  - MinIO
+  - InfluxDB
+- Monitoring and Logging, see OpenCRVS dependencies helm chart for exact versions:
+  - Kibana
+  - Logstash
+  - Filebeat
+  - Metricbeat
+  - Elastic APM server
+  - Elastalert2
+- OpenCRVS services are deployed with Farajaland data and MOSIP integration enabled:
+  - Core packages version: 0f10027
+  - Farajaland version: 3314a9a
+- MOSIP package
+
+# Prerequisites
+
+1. 3 VMs has at least:
+  - Master 2cpu/4G RAM/10G ssd
+  - Workers 8cpu/16G RAM/50G ssd
+2. Linux distribution Ubuntu 24.04 is installed on VM
+3. At least master VM has public IP, or at least you have option to open ports 80 and 443, otherwise traefik will not be able to issue valid SSL Certificates with lets encrypt http-01 challenge.
+4. Valid Domain name is attached to VM. You need to have 2 `A` records:
+   - Primary domain for master VMs IP address (e/g: opencrvs.example.com)
+   - Wildcard for primary domain or list of sub-domains mapped to master VMs IP address.
+   
+   For more information, please check https://documentation.opencrvs.org/setup/3.-installation/3.3-set-up-a-server-hosted-environment/3.3.5-setup-dns-a-records#domain-a-records
+5. Provision user is configured according to documentation at [3.3.1-provision-your-server-nodes-with-ssh-access](https://documentation.opencrvs.org/setup/3.-installation/3.3-set-up-a-server-hosted-environment/3.3.1-provision-your-server-nodes-with-ssh-access)
+6. Make sure new ssh key-pair is generated on master:
+  - On master node run `ssh-keygen`, feel free to use defaults
+  - On master node keep private and public keys in /home/provision/.ssh
+  - On worker node keep only public key in /home/provision/.ssh/authorized_keys
+  - Make sure command `ssh <worker node ip>` works without asking for password
+
+# Deploy OpenCRVS with Github Actions workflows
+
+## Prerequisites
+
+> NOTE: `(Optional)` steps should be performed only once per multiple environments
+
+1. (Optional) Fork repository: https://github.com/opencrvs/infrastructure
+2. (Optional) Create repository level secrets:
+   - GH_TOKEN with read/write access to workflows
+   - K8S_RUNNER_TOKEN, Kubernetes self-hosted runner secret
+2. Create GitHub environment `demo`
+3. Create following GitHub secrets  under `demo` environment:
+   - ENCRYPTION_KEY, `/data` partition encryption key, store secret to password manager for future usage
+4. Create following GitHub variables under `demo` environment:
+   - DISK_SPACE, encrypted partition disk size, for testing 5g is more then sufficient
+   - DOMAIN, domain name attached to your VM
+
+## Bootstrap github self-hosted runner
+
+Make sure you have following values:
+- github org name: `<your account or org name>`
+- github repository name: `<your repository name>`
+- github PAT with access to repository code and workflow: `<K8S_RUNNER_TOKEN or dedicated runner token>`
+- environment name: `demo`
+
+Run following command on VM (master node):
+```
+curl -s https://raw.githubusercontent.com/opencrvs/infrastructure/refs/heads/develop/github-runner/node-runner.sh -o runner.sh && bash runner.sh
+```
+You should see a message:
+```
+✅ Runner '....-runner' is installed and started!
+```
+In your github repository you should see a self-hosted runner under settings/actions/runners
+
+## Prepare inventory file
+
+1. Go to `infrastructure/server-setup/inventory` folder
+2. Create configuration file for your dev VM, name should match with GitHub environment name, e/g if your environment name is `demo` then file name should be `demo.yml`. See example.
+3. Commit your changes
+4. Make sure update-envs workflow completed before moving to the next section.
+
+Configuration file example:
+```yaml
+all:
+  vars:
+    kube_api_sans:
+    - test-k8s.opencrvs.dev
+    ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+    ansible_user: provision
+    users:
+      - name: demo
+        ssh_keys:
+          - ssh-ed25519 AAAAC3NzaC....i2DqV7g/Q
+        state: present
+        role: admin
+  children:
+    master:
+      hosts:
+        test-k8s-master:
+          ansible_host: 10.2.1.1
+
+    workers:
+      hosts:
+        test-k8s-worker-0:
+          ansible_host: 10.2.1.2
+        test-k8s-worker-1:
+          ansible_host: 10.2.1.3
+```
+
+## Run provision
+
+- Run provision workflow
+- Make sure kubernetes self-hosted runner is available at settings/actions/runners
+
+## Run Dependencies deployment workflow
+
+Review file `examples/demo/dependencies/values.yaml` and if needed adjust values, defaults should be good for starting point
+
+
+- Label kubernetes nodes:
+  ```
+  kubectl label node test-k8s-worker-0 role=data1
+  kubectl label node test-k8s-worker-1 role=data2
+  ```
+- Run Dependencies deployment workflow
+- Make sure minio and kibana are available
+
+## Run OpenCRVS deployment workflow
+
+Review file `examples/demo/opencrvs-services/values.yaml` and if needed adjust values, defaults should be good for starting point
+
+- Run OpenCRVS deployment workflow
+- Make sure login page is available
+
+# Manual Deployment on existing kubernetes cluster
+
+> NOTE: If you would like to provision infrastructure and kubernetes cluster with ansible scripts developed by OpenCRVS Team, please use [Deploy with Github](#deploy-with-github) scenario. Manual deployment scenario covers only OpenCRVS and dependencies installation.
+
+## Prerequisites
+
+Single-node Kubernetes cluster is up and running on your VM.
+   Make sure you are able connect to the cluster with kubectl
+   ```
+   kubectl get nodes
+   ```
+
+## Installation process
+
+> ℹ️ All commands should be started from `examples/dev` directory
+
+1. Deploy traefik
+   ```
+   helm upgrade --install traefik traefik-repo/traefik \
+   --namespace traefik \
+   --create-namespace \
+   -f traefik/values.yaml
+   ```
+2. Install OpenCRVS dependencies
+    > ⚠️ Update `<your_host_name>` placeholder before running command
+    ```
+    helm upgrade --install opencrvs-deps oci://ghcr.io/opencrvs/opencrvs-dependencies-chart \
+    --namespace "opencrvs-deps-dev" \
+    -f examples/dev/dependencies/values.yaml \
+    --create-namespace \
+    --set storage_type=host_path \
+    --set hostname=<your_host_name>
+    ```
+3. Install OpenCRVS MOSIP integration
+    > ⚠️ Update `<your_host_name>` placeholder before running command
+    ```
+    helm upgrade --install mosip-api oci://ghcr.io/opencrvs/opencrvs-mosip \
+        --namespace "opencrvs-dev" \
+        -f mosip-api/values.yaml \
+        --create-namespace \
+        --atomic \
+        --set hostname=<your_host_name>
+    ```
+4. Copy secrets from dependencies to main namespace:
+   ```
+   ENV=demo
+   secrets=(
+        "elasticsearch-admin-user"
+        "redis-opencrvs-users"
+        "minio-opencrvs-users"
+        "mongodb-admin-user"
+        "postgres-admin-user"
+    )
+    for secret in "${secrets[@]}"; do
+        kubectl get secret $secret -n opencrvs-deps-${ENV} -o yaml \
+        | sed "s#namespace: opencrvs-deps-${ENV}#namespace: opencrvs-${ENV}#" \
+        | grep -vE 'resourceVersion|uid|creationTimestamp' \
+        | kubectl apply -n opencrvs-${ENV} -f - 
+    done
+   ```
+5. Install OpenCRVS
+    > ⚠️ Update `<your_host_name>` placeholder before running command
+    ```
+    helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
+        --timeout 15m \
+        --namespace "opencrvs-demo" \
+        -f opencrvs-services/values.yaml \
+        --create-namespace \
+        --atomic \
+        --set hostname=<your_host_name>
+    ```
+6. Seed data
+    ```
+    helm get values opencrvs --namespace "opencrvs-demo" \
+       | helm template -f - \
+            --set data_seed.enabled=true \
+            --namespace "opencrvs-demo" \
+            -s templates/data-seed-job.yaml \
+            oci://ghcr.io/opencrvs/opencrvs-services \
+       | kubectl apply --namespace "opencrvs-demo" -f -
+    ```

--- a/examples/stg/dependencies/README.md
+++ b/examples/stg/dependencies/README.md
@@ -1,0 +1,9 @@
+ENV=demo;
+
+
+helm upgrade --install opencrvs-deps charts/dependencies/ \
+            --namespace "opencrvs-deps-${ENV}" \
+            -f examples/${ENV}/dependencies/values.yaml \
+            --create-namespace \
+            --set environment="$ENV" \
+            --set storage_type=host_path

--- a/examples/stg/dependencies/values.yaml
+++ b/examples/stg/dependencies/values.yaml
@@ -1,0 +1,33 @@
+chart_dev_mode: false
+hostname: test-k8s.opencrvs.dev
+storage_type: host_path
+node_selector:
+  role: data2
+
+ingress:
+  tls_resolver: letsencrypt
+
+redis:
+  auth_mode: disabled
+
+minio:
+  use_default_credentials: false
+
+elasticsearch:
+  use_default_credentials: false
+  node_selector:
+    role: data1
+mongodb:
+  use_default_credentials: false
+
+postgres:
+  use_default_credentials: false
+
+monitoring:
+  enabled: false
+
+backup:
+  enabled: true
+
+restore:
+  enabled: true

--- a/examples/stg/mosip-api/values.yaml
+++ b/examples/stg/mosip-api/values.yaml
@@ -1,0 +1,2 @@
+ingress:
+  ssl_enabled: true

--- a/examples/stg/opencrvs-services/README.md
+++ b/examples/stg/opencrvs-services/README.md
@@ -1,0 +1,56 @@
+
+secrets=(
+    "redis-opencrvs-users"
+    "minio-opencrvs-users"
+)
+for secret in "${secrets[@]}"; do
+    kubectl get secret $secret -n opencrvs-deps-${ENV} -o yaml \
+    | sed "s#namespace: opencrvs-deps-${ENV}#namespace: opencrvs-${ENV}#" \
+    | grep -vE 'resourceVersion|uid|creationTimestamp' \
+    | kubectl apply -n opencrvs-${ENV} -f - \
+    || echo "Secret $secret doesn't exist in opencrvs-deps-${ENV} namespace"
+done
+
+helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services:0.0.1 \
+    --namespace "opencrvs-${ENV}" \
+    -f infrastructure/${ENV}/opencrvs-services/values.yaml \
+    --create-namespace \
+    --set core.image.tag="$CORE_IMAGE_TAG" \
+    --set countryconfig.image.tag="$COUNTRYCONFIG_IMAGE_TAG" \
+    --set environment="$ENV"
+
+helm template  -f infrastructure/${ENV}/opencrvs-services/values.yaml \
+    --set data_seed.enabled=true \
+    -s templates/data-seed-job.yaml \
+    oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -f -
+
+DOMAIN=aws.opencrvs.dev
+
+
+
+TOKEN=`curl -X POST "https://auth.aws.opencrvs.dev/authenticate-super-user" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "username": "o.admin",
+       "password": "'"$SUPER_USER_PASSWORD"'"
+     }' | jq .token`
+
+curl -H "Authorization: Bearer $TOKEN"  -X GET https://countryconfig.aws.opencrvs.dev/locations
+curl -H "Authorization: Bearer $TOKEN"  -X GET https://config.aws.opencrvs.dev/locations?type=ADMIN_STRUCTURE&_count=0
+curl -H "Authorization: Bearer $TOKEN"  -X GET https://gateway.aws.opencrvs.dev/locations?type=ADMIN_STRUCTURE&_count=0
+
+
+
+helm template -f infrastructure/${ENV}/opencrvs-services/values.yaml \
+    --set data_cleanup.enabled=true \
+    -s templates/data-cleanup-job.yaml \
+    oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -f -
+
+helm template -f infrastructure/${ENV}/opencrvs-services/values.yaml \
+    -s templates/data-migration-job.yaml \
+    oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -f -
+
+helm template  -f infrastructure/${ENV}/opencrvs-services/values.yaml \
+    --set data_seed.enabled=true \
+    -s templates/data-seed-job.yaml \
+    oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -f -

--- a/examples/stg/opencrvs-services/values.yaml
+++ b/examples/stg/opencrvs-services/values.yaml
@@ -1,0 +1,70 @@
+chart_dev_mode: false
+
+ingress:
+  tls_resolver: letsencrypt
+
+hpa:
+  enabled: false
+
+env:
+  APN_SERVICE_URL: "http://apm-server.opencrvs-deps-demo.svc.cluster.local:8200"
+
+hostname: test-k8s.opencrvs.dev
+influxdb:
+  host: influxdb-0.influxdb.opencrvs-deps-demo.svc.cluster.local
+elasticsearch:
+  auth_mode: auto
+  port: 9200
+  host: elasticsearch.opencrvs-deps-demo.svc.cluster.local
+
+
+minio:
+  auth_mode: use_secret
+  host: minio-0.minio.opencrvs-deps-demo.svc.cluster.local
+  external_hostname: minio.test-k8s.opencrvs.dev
+
+mongodb:
+  auth_mode: auto
+  host: mongodb-0.mongodb.opencrvs-deps-demo.svc.cluster.local
+
+redis:
+  auth_mode: disabled
+  host: redis-0.redis.opencrvs-deps-demo.svc.cluster.local
+
+postgres:
+  auth_mode: auto
+  host: postgres-0.postgres.opencrvs-deps-demo.svc.cluster.local
+
+resources:
+  memoryRequest: "256Mi"
+  cpuRequest: "200m"
+  memoryLimit: "2Gi"
+  cpuLimit: "1"
+
+image:
+  tag: 0f10027
+
+dashboards:
+  use_default_credentials: false
+
+countryconfig:
+  image:
+    # Replace countryconfig with farajaland to test data
+    name: opencrvs/ocrvs-farajaland
+    # name: opencrvs/ocrvs-countryconfig
+    tag: 3314a9a
+    # tag: ec53c12
+    # tag: v1.8.1
+
+  env:
+    OPENID_PROVIDER_CLAIMS: name,family_name,given_name,middle_name,birthdate,address
+    OPENID_PROVIDER_CLIENT_ID: mock-client_id
+    V2_EVENTS: "true"
+    FIXME: In general these values should be passed externally using `--set key=value`
+    ESIGNET_REDIRECT_URL: https://esignet-mock.test-k8s.opencrvs.dev/authorize
+    MOSIP_API_USERINFO_URL: https://mosip-api.test-k8s.opencrvs.dev/esignet/get-oidp-user-info
+
+data_seed:
+  env:
+    SUPER_USER_PASSWORD: "password"
+    ACTIVATE_USERS: "true"

--- a/examples/stg/traefik/README.md
+++ b/examples/stg/traefik/README.md
@@ -1,0 +1,13 @@
+
+# Install Traefik
+```
+helm upgrade --install traefik traefik-repo/traefik --namespace traefik --create-namespace -f values.yaml
+```
+# Update domain name for new load balancer
+
+```
+kubectl get svc -n traefik
+```
+
+Create CNAME/A/AAA for Load balancer name. Lets encrypt works fine with CNAME.
+

--- a/examples/stg/traefik/values.yaml
+++ b/examples/stg/traefik/values.yaml
@@ -1,0 +1,81 @@
+# Overwriting https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml
+namespaceOverride: "traefik"
+logs:
+  general:
+    # "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL", "PANIC"
+    level: "INFO"
+    # format: "common" # For local environment
+    format: "json" # For server environment
+  access:
+    # -- To enable access logs
+    enabled: true
+    format: "json"
+ingressRoute:
+  dashboard:
+    enabled: false
+
+# Be explicit that we only use CRDs, not ingress/gw support
+providers: 
+  kubernetesCRD:
+    enabled: true
+  kubernetesIngress:
+    enabled: true
+  kubernetesGateway:
+    enabled: false
+
+service:
+  enabled: true
+  single: false
+  type: NodePort
+
+ports:
+  web:
+    port: 8000
+    hostPort: 80
+    protocol: TCP
+    nodePort: 30080
+  websecure:
+    port: 8443
+    nodePort: 30443
+    hostPort: 443
+    protocol: TCP
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      tlsChallenge: false
+      httpChallenge:
+        entryPoint: web
+      email: vadym@opencrvs.org
+      # Storage for production certificates:
+      # storage: /data/acme.json
+      # Storage for staging certificates:
+      storage: /data/acme-staging.json
+      # Staging server
+      caServer: https://acme-staging-v02.api.letsencrypt.org/directory
+      # Production server
+      # caServer: https://acme-v02.api.letsencrypt.org/directory
+
+# Additional arguments
+additionalArguments:
+  - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
+  - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
+  - "--certificatesresolvers.letsencrypt.acme.email=vadym@opencrvs.org"
+  # Storage for staging certificates:
+  - "--certificatesresolvers.letsencrypt.acme.storage=/data/acme-staging.json"
+  # Storage for staging certificates:
+  # - "--certificatesresolvers.letsencrypt.acme.storage=/data/acme.json"
+
+deployment:
+  hostNetwork: true
+  additionalVolumes:
+    - name: acme
+      hostPath:
+        path: /data/traefik
+
+# additionalVolumeMounts:
+#   - name: acme
+#     mountPath: /data
+
+nodeSelector:
+  traefik-role: ingress

--- a/infrastructure/server-setup/tasks/k8s/install-containerd.yml
+++ b/infrastructure/server-setup/tasks/k8s/install-containerd.yml
@@ -23,8 +23,8 @@
 
 - name: Install containerd
   shell: |
-    apt update
-    apt install -y containerd.io
+    apt-get update
+    apt-get install -y containerd.io
 
 - name: Create containerd configuration directory
   shell: mkdir -p /etc/containerd

--- a/infrastructure/server-setup/tasks/k8s/install-kubernetes.yml
+++ b/infrastructure/server-setup/tasks/k8s/install-kubernetes.yml
@@ -17,7 +17,7 @@
   shell: echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{ kubernetes_version }}/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list
 
 - name: Update apt cache and install Kubernetes components
-  shell: apt update && apt install -y kubelet kubeadm kubectl
+  shell: apt-get update && apt-get install -y kubelet kubeadm kubectl
 
 - name: Hold Kubernetes packages
   shell: apt-mark hold kubelet kubeadm kubectl

--- a/infrastructure/server-setup/tasks/k8s/install-network-plugin.yml
+++ b/infrastructure/server-setup/tasks/k8s/install-network-plugin.yml
@@ -1,4 +1,3 @@
-# TODO: Make Kubernetes components
 ---
 - name: Install Tigera Operator
   shell: kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/{{ calico_version }}/manifests/tigera-operator.yaml


### PR DESCRIPTION
Added MinIO restore feature

Key benefits:
- minio restart is not required since we moved to minio/mc command line interface
- no need to setup special (ReadWriteMany) persistent volume claim or share same volume within few containers (minio server, backup and restore)
- Independent backup/restore servers configuration, e/g staging environment may have it's own backup server while production backup could be stored separately. There are no configuration limit.

Next steps:
- Decide if we need filesystem restore option for MinIO
- Decide moving to cronjob if filesystem restore is not needed