### PR TITLE
Wait for jobs to finish before calling deployment done

### DIFF
--- a/.github/workflows/deploy-opencrvs.yml
+++ b/.github/workflows/deploy-opencrvs.yml
@@ -95,6 +95,8 @@ jobs:
             -f https://raw.githubusercontent.com/opencrvs/infrastructure/refs/heads/${{ github.ref_name }}/examples/${ENV}/opencrvs-services/values.yaml \
             --create-namespace \
             --atomic \
+            --wait \
+            --wait-for-jobs \
             --set image.tag="$CORE_IMAGE_TAG" \
             --set countryconfig.image.tag="$COUNTRYCONFIG_IMAGE_TAG" \
             --set hostname=${{ vars.DOMAIN }}


### PR DESCRIPTION
0. Job might not be finished before we mark deployment successful
1. In the worst case, CI workflow starts resetting postgres while migration is running
2. we end up without database in e2e environment. Migration & events going to crash loop

https://github.com/opencrvs/infrastructure/blob/91e5ca8bc94967a5f650e5eebc81b968315ac4a0/charts/opencrvs-services/templates/data-migration-job.yaml

```
      --wait                                       if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful. It will wait for as long as --timeout
      --wait-for-jobs                              if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as --timeout
```