### PR TITLE
chore: add delete condition for apm logs

### DIFF
--- a/charts/dependencies/files/apm-server/apm-server.yml
+++ b/charts/dependencies/files/apm-server/apm-server.yml
@@ -9,7 +9,7 @@ apm-server:
     enabled: 'auto'
     setup:
       enabled: true
-      overwrite: false
+      overwrite: true # allow overwriting the policy on redeploy
       require_policy: true
       mapping:
         - event_type: 'error'
@@ -44,6 +44,10 @@ apm-server:
                   set_priority:
                     priority: 50
                   readonly: {}
+              delete:
+                min_age: '2d'
+                actions:
+                  delete: {}
 queue:
   mem:
     events: 12096

--- a/charts/dependencies/files/beats/rollover-policy.json
+++ b/charts/dependencies/files/beats/rollover-policy.json
@@ -5,7 +5,7 @@
         "min_age": "0ms",
         "actions": {
           "rollover": {
-            "max_age": "3d",
+            "max_age": "1d",
             "max_size": "200mb"
           }
         }


### PR DESCRIPTION
In k8s e2e environment, we have ran out of disk space few times. More was added but instead of deleting log indices manually, we’ll need to add shorter delete policies for ELK stack items so we don’t repeat this exercise too often.

https://github.com/opencrvs/opencrvs-core/issues/10432


