### PR TITLE
fix: remove extra '-' at the end

### DIFF
--- a/charts/opencrvs-services/templates/data-cleanup-job.yaml
+++ b/charts/opencrvs-services/templates/data-cleanup-job.yaml
@@ -133,7 +133,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              approved_words="${ES_INDEX_PREFIX:-events}_ ${ELASTICSEARCH_INDEX_NAME:-ocrvs}-"
+              approved_words="${ES_INDEX_PREFIX:-events}_ ${ELASTICSEARCH_INDEX_NAME:-ocrvs}"
               indices=$(curl -sS -XGET http://$ELASTICSEARCH_HOST/_cat/indices?h=index)
               echo "Running elasticsearch cleanup script..."
               echo "--------------------------"


### PR DESCRIPTION
During the clean up of the elasticsearch indices, the prefix used to filter the v1 index name had an extra '-' at the end which was causing it to miss cleaning up the v1 index. As a result, indexed data from previous deployments persisted across deployments. These records did not show up in the workqueues due to the `primaryOfficeId` search criteria being present, but when searched for a record using name for example, indexed records from previous deployments may get returned. And the probability for this increases the more you run E2Es against the same branch.

Now the `authorization error` happens when any of the stale indexed records has assignment data because to resolve that a `find user by practitionnerId` is performed. But no user is found with that particular `practitionnerId`.