### PR TITLE
fix: Refactor job workflow to run before and after OpenCRVS installation

### DIFF
--- a/charts/opencrvs-services/templates/postgres-migration-job.yaml
+++ b/charts/opencrvs-services/templates/postgres-migration-job.yaml
@@ -6,11 +6,11 @@ metadata:
   # - https://github.com/opencrvs/opencrvs-core/issues/7451
   # - https://opencrvsworkspace.slack.com/archives/C02LU432JGK/p1757940561135439
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "1"
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "2"
   labels:
     app: migration
-  name: {{ .Values.data_migration.job_name | default "data-migration" }}
+  name: postgres-{{ .Values.data_migration.job_name | default "data-migration" }}
 spec:
   template:
     metadata:
@@ -20,6 +20,22 @@ spec:
       containers:
         - name: migration
           image: "ghcr.io/opencrvs/ocrvs-migration:{{ .Values.image.tag }}"
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              # events migrations
+              export EVENTS_DB_USER="${EVENTS_DB_USER:-events_app}"
+              SCRIPT_PATH=/app/packages/migration
+              MIGRATIONS_PATH=$SCRIPT_PATH/src/migrations/events
+              for migration_file in $(ls $MIGRATIONS_PATH)
+              do
+                echo "Updating environment variables in $MIGRATIONS_PATH/$migration_file"
+                envsubst < $MIGRATIONS_PATH/$migration_file > $MIGRATIONS_PATH/$migration_file.tmp
+                mv $MIGRATIONS_PATH/$migration_file.tmp $MIGRATIONS_PATH/$migration_file
+              done
+              DATABASE_URL=${EVENTS_POSTGRES_URL} yarn --cwd $SCRIPT_PATH node-pg-migrate up --schema=app --migrations-dir=./src/migrations/events
+
+          # FIXME: Delete not-used environment variables
           env:
           {{- if eq .Values.elasticsearch.auth_mode "disabled" }}
             - name: ES_HOST

--- a/environments/dev/opencrvs-services/values.yaml
+++ b/environments/dev/opencrvs-services/values.yaml
@@ -48,7 +48,7 @@ image:
   tag: 0f10027
 
 dashboards:
-  use_default_credentials: false
+  enabled: false
 
 countryconfig:
   image:

--- a/examples/dev/opencrvs-services/values.yaml
+++ b/examples/dev/opencrvs-services/values.yaml
@@ -45,7 +45,7 @@ image:
   tag: 0f10027
 
 dashboards:
-  use_default_credentials: false
+  enabled: false
 
 countryconfig:
   image:


### PR DESCRIPTION
Job was setup as post-deploy hook initially, but moved to part of helm chart temporary as workaround to https://github.com/opencrvs/opencrvs-core/issues/10512

Events service requires postgres DB to have users.

Goal of this PR is to split postgres DB migration as separate pre-install/pre-deploy hook. Change will make events service more reliable at first deploy.

While running helm install/upgrade command containers will be created in following order:
- postgres-migration
- events
- data-migration

In current implementation postgres migration will run twice in `postgres-migration` and `data-migration` containers.

NOTE: Kubernetes jobs are immutable objects and fields like `image` can't be changes. There is no way to start existing job after transition to Completed state.


Next steps:
- Cleanup postgres migration job from not-used variables
- Write separate scripts for database migration and reindex