### PR TITLE
fix: Make deployment order more restricted

### DIFF
--- a/.github/workflows/k8s-reset-data.yml
+++ b/.github/workflows/k8s-reset-data.yml
@@ -59,16 +59,36 @@ jobs:
             kubectl wait --for=condition=complete job/data-cleanup -n ${namespace} --timeout=600s;
             kubectl delete pod -n ${namespace} -lapp=events;
             kubectl wait --for=condition=ready pod -n ${namespace} -lapp=events;
-        - name: Re-run postgres on-deploy
+        - name: Re-run postgres on-update-core
           run: |
-            kubectl delete job -n ${namespace} --ignore-not-found=true postgres-on-deploy;
+            kubectl delete job -n ${namespace} --ignore-not-found=true postgres-on-update-core;
             helm template -f ${namespace}.json \
-                -s templates/postgres-on-update.yaml \
+                --namespace ${namespace} \
+                -s templates/postgres-on-update-core.yaml \
+                oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -n ${namespace} --wait=true -f -;
+            sleep 30;
+            kubectl logs job/postgres-on-update-core -f --all-containers=true -n ${namespace};
+            kubectl wait --for=condition=complete job/postgres-on-update-core -n ${namespace} --timeout=600s;
+        - name: Re-run postgres db-migration
+          run: |
+            kubectl delete job -n ${namespace} --ignore-not-found=true postgres-db-migration;
+            helm template -f ${namespace}.json \
+                --namespace ${namespace} \
+                -s templates/postgres-db-migration.yaml \
+                oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -n ${namespace} --wait=true -f -;
+            sleep 30;
+            kubectl logs job/postgres-db-migration -f --all-containers=true -n ${namespace};
+            kubectl wait --for=condition=complete job/postgres-db-migration -n ${namespace} --timeout=600s;
+        - name: Re-run postgres on-update-analytics
+          run: |
+            kubectl delete job -n ${namespace} --ignore-not-found=true postgres-on-update-analytics;
+            helm template -f ${namespace}.json \
+                -s templates/postgres-on-update-analytics.yaml \
                 --namespace ${namespace} \
                 oci://ghcr.io/opencrvs/opencrvs-services | kubectl apply -n ${namespace} --wait=true -f -;
             sleep 30;
-            kubectl logs job/postgres-on-deploy -f --all-containers=true -n ${namespace};
-            kubectl wait --for=condition=complete job/postgres-on-deploy -n ${namespace} --timeout=600s;
+            kubectl logs job/postgres-on-update-analytics -f --all-containers=true -n ${namespace};
+            kubectl wait --for=condition=complete job/postgres-on-update-analytics -n ${namespace} --timeout=600s;
         - name: Migration
           run: |
             kubectl delete job -n ${namespace} --ignore-not-found=true data-migration-on-reset

--- a/charts/opencrvs-services/templates/countryconfig-deployment.yaml
+++ b/charts/opencrvs-services/templates/countryconfig-deployment.yaml
@@ -67,6 +67,10 @@ spec:
       app: countryconfig
   template:
     metadata:
+      # TODO: If force-restart works well, apply to the rest of templates
+      # We rotate secrets every deploy, pods need to be restarted as well
+      annotations:
+        lastdeploy-timestamp: {{ now | quote }}
       labels:
         app: countryconfig
         service_name: opencrvs_countryconfig

--- a/charts/opencrvs-services/templates/events-deployment.yaml
+++ b/charts/opencrvs-services/templates/events-deployment.yaml
@@ -42,6 +42,10 @@ spec:
       app: events
   template:
     metadata:
+      # TODO: If force-restart works well, apply to the rest of templates
+      # We rotate secrets every deploy, pods need to be restarted as well
+      annotations:
+        lastdeploy-timestamp: {{ now | quote }}
       labels:
         app: events
         service_name: opencrvs_events

--- a/charts/opencrvs-services/templates/postgres-on-update-analytics.yaml
+++ b/charts/opencrvs-services/templates/postgres-on-update-analytics.yaml
@@ -1,0 +1,84 @@
+{{- if or (eq .Values.postgres.auth_mode "auto") (eq .Values.postgres.auth_mode "disabled") }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "3"
+  labels:
+    app: postgres-on-update-analytics
+  name: postgres-on-update-analytics
+spec:
+  template:
+    metadata:
+      labels:
+        app: postgres-on-update-analytics
+    spec:
+      containers:
+        - name: postgres-on-update-analytics
+          command: ["bash", "-c", "/scripts/setup-analytics.sh"]
+          # command: ["bash", "-c", "/scripts/on-deploy.sh;"]
+          image: "postgres:17"
+          env:
+            - name: POSTGRES_HOST
+              value: {{ .Values.postgres.host }}
+            - name: POSTGRES_PORT
+              value: "5432"
+          {{- if eq .Values.postgres.auth_mode "disabled" }}
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              value: postgres
+          {{- else }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.admin_user_secret_name }}
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.admin_user_secret_name }}
+                  key: POSTGRES_PASSWORD
+          {{- end }}
+            - name: EVENTS_APP_ROLE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.users_secret }}
+                  key: EVENTS_APP_POSTGRES_USER
+            - name: EVENTS_APP_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.users_secret }}
+                  key: EVENTS_APP_POSTGRES_PASSWORD
+            - name: EVENTS_MIGRATOR_ROLE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.users_secret }}
+                  key: EVENTS_MIGRATOR_POSTGRES_USER
+            - name: EVENTS_MIGRATOR_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.users_secret }}
+                  key: EVENTS_MIGRATOR_POSTGRES_PASSWORD
+            - name: ANALYTICS_POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.users_secret }}
+                  key: EVENTS_ANALYTICS_POSTGRES_USER
+            - name: ANALYTICS_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.users_secret }}
+                  key: EVENTS_ANALYTICS_POSTGRES_PASSWORD
+          {{- include "render-env-vars" (dict "service_name" "postgres_on_deploy" "Values" .Values) }}
+          volumeMounts:
+            - mountPath: /scripts
+              name: postgres-on-update-script
+      volumes:
+        - name: postgres-on-update-script
+          configMap:
+            name: postgres-on-update-script
+            defaultMode: 0755
+      restartPolicy: "OnFailure"
+{{- end }}

--- a/charts/opencrvs-services/templates/postgres-on-update-core.yaml
+++ b/charts/opencrvs-services/templates/postgres-on-update-core.yaml
@@ -6,18 +6,17 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "1"
   labels:
-    app: postgres-on-deploy
-  name: postgres-on-deploy
+    app: postgres-on-update-core
+  name: postgres-on-update-core
 spec:
   template:
     metadata:
       labels:
-        app: postgres-on-deploy
+        app: postgres-on-update-core
     spec:
       containers:
-        - name: postgres-on-deploy
-          command: ["bash", "-c", "/scripts/on-deploy.sh; /scripts/setup-analytics.sh"]
-          # command: ["bash", "-c", "/scripts/on-deploy.sh;"]
+        - name: postgres-on-update-core
+          command: ["bash", "-c", "/scripts/on-deploy.sh"]
           image: "postgres:17"
           env:
             - name: POSTGRES_HOST


### PR DESCRIPTION
This PR aims to fix issue https://github.com/opencrvs/opencrvs-core/issues/10576

Postgres database migrations are made more restricted:
- Core users (events_app, events_app_migration) and schemas are created as pre-requisite for migration
- Next one Core migration script for postgres executed
- Finally analytics migrations are executed with references to core migration artifacts (tables, schemas, etc)