### PR TITLE
fix: Provision script takes public IP address as default interface on the system

### DIFF
--- a/infrastructure/environments/templates/inventory/multi-node.yml
+++ b/infrastructure/environments/templates/inventory/multi-node.yml
@@ -1,31 +1,77 @@
 all:
   vars:
+    # single_node:
+    # For development/qa/testing/staging keep true
+    # For production keep false
+    # Defaults production configuration:
+    # - master node
+    # - 2 worker nodes
     single_node: false
-    kube_api_sans: {}
+
+    # Add IP addresses or domain names for communication with your cluster from your laptop
+    # NOTE: First item in this list will be added as main endpoint to your ~/.kube/config
+    # - If you are behind VPN, use private IP address
+    # - If your server is exposed (not recommeded), use public IP address
+    # - If you would like to run kubectl commands from the remote server, leave this field empty
+    kube_api_sans: []
+
+    # IMPORTANT: If master VM has multiple ethernet interfaces, put private IP address at kube_api_address
+    # kube_api_address: 10.10.10.10
+
+    # Default ansible provision user, keep as is
     ansible_user: provision
-    users: {}
+
+    # users: Add as many users as you wish
+    # Configuration example
+    # - name: <login>
+    #   ssh_keys:
+    #     - <public ssh key 1>
+    #     - <public ssh key 2>
+    #   state: present
+    #   role: admin
+    # Allowed roles:
+    # - operator, read only access to OS, full access to kubernetes cluster
+    # - admin, full access
+    # Allowed states:
+    # - present, user is allowed to login
+    # - absent, account is disabled
+    users: []
+
   children:
     master:
       hosts:
-        # TODO: Add master primary node template
-        test-k8s-master:
-          ansible_host: 10.2.1.1
+        # Replace master with value returned by command: hostname 
+        master:
+          # Keep values (ansible_host, ansible_connection) as is
+          # Ansible is executed on master node
+          ansible_host: localhost
+          ansible_connection: local
           labels:
-            role: data0
+            # traefik-role label is used to identify where to deploy traefik
             traefik-role: ingress
 
+    # Workers section is optional, for single node cluster feel free to remove this section
+    # section can be added later
+    # more workers can be added later as well
     workers:
       hosts:
-        # TODO: Add worker node template
-        test-k8s-worker-0:
-          ansible_host: 10.2.1.2
+        # Replace worker0 with value returned by command: hostname
+        worker0:
+          # Put internal IP address here
+          ansible_host: 10.10.10.10
           labels:
+            # By default all datastores are deployed to worker node with role data1
             role: data1
-            foo: bar
-        test-k8s-worker-1:
-          ansible_host: 10.2.1.3
+        # Replace worker0 with value returned by command: hostname
+        worker1:
+           # Put internal IP address here
+          ansible_host: 10.10.10.11
+
+    # backup section is optional, feel free to remove if backups are not enabled
+    # section can be added later
     backup:
       hosts:
-        # TODO: Add backup server template
+        # Replace backup-01 with value returned by command: hostname
         backup-01:
-          ansible_host: 10.2.1.4
+          # Put internal IP address here
+          ansible_host: 10.10.10.12

--- a/infrastructure/environments/templates/inventory/single-node.yml
+++ b/infrastructure/environments/templates/inventory/single-node.yml
@@ -6,17 +6,40 @@ all:
     # - If your server is exposed (not recommeded), use public IP address
     # - If you would like to run kubectl commands from the remote server, leave this field empty
     kube_api_sans: []
-    # Keep default
+
+    # Default ansible provision user, keep as is
     ansible_user: provision
+
+    # single_node:
     # For development/qa/testing/staging keep true
     # For production keep false
+    # Defaults production configuration:
+    # - master node
+    # - 2 worker nodes
     single_node: true
-     # Add as many users as you wish
+
+    # users: Add as many users as you wish
+    # Configuration example
+    # - name: <login>
+    #   ssh_keys:
+    #     - <public ssh key 1>
+    #     - <public ssh key 2>
+    #   state: present
+    #   role: admin
+    # Allowed roles:
+    # - operator, read only access to OS, full access to kubernetes cluster
+    # - admin, full access
+    # Allowed states:
+    # - present, user is allowed to login
+    # - absent, account is disabled
     users: []
+
   children:
     master:
       hosts:
-        # IMPORTANT: Update with your real host name
-        test-k8s-master:
+        # Replace master with value returned by command: hostname
+        master:
+          # Keep values (ansible_host, ansible_connection) as is
+          # Ansible is executed on master node
           ansible_host: localhost
           ansible_connection: local

--- a/infrastructure/server-setup/tasks/k8s/init-master.yml
+++ b/infrastructure/server-setup/tasks/k8s/init-master.yml
@@ -8,9 +8,9 @@
   when: not k8s_init_check.stat.exists
   shell: |
     sudo kubeadm init \
-      --apiserver-advertise-address={{ ansible_default_ipv4.address }} \
+      --apiserver-advertise-address={{ kube_api_address | default(ansible_default_ipv4.address) }} \
       --pod-network-cidr={{ pod_network_cidr }} \
-      --control-plane-endpoint={{ ansible_default_ipv4.address }}
+      --control-plane-endpoint={{ kube_api_address | default(ansible_default_ipv4.address) }}
   register: kubeadm_init_result
 
 - name: Create .kube directory for provision user


### PR DESCRIPTION
# Description

> NOTE: PR also contains update to configuration templates

Related issue: https://github.com/opencrvs/opencrvs-core/issues/10619

This PR aims to fix issue while provisioning multiple node  kubernetes cluster with multiple ethernet interfaces on each node.

By default first ethernet interface on master node is used as Kubernetes API endpoint for workers, as a result worker nodes are not reachable with ufw enabled.

# Testing

Test environment was built on hetzner:
<img width="1193" height="325" alt="image" src="https://github.com/user-attachments/assets/b28bc1f9-393b-4b71-a9e4-afd455cecce4" />

Provision script executed: https://github.com/opencrvs/infrastructure/actions/runs/18322684071

Kubelet configuration generated on worker node:

```
provision@testland-k8s-worker-1:~$ sudo cat /etc/kubernetes/kubelet.conf 
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: LS0tLRCtocjh....FUlRJRklDQVRFLS0tLS0K
    server: https://10.2.1.1:6443
  name: default-cluster
contexts:
- context:
    cluster: default-cluster
    namespace: default
    user: default-auth
  name: default-context
current-context: default-context
kind: Config
preferences: {}
users:
- name: default-auth
  user:
    client-certificate: /var/lib/kubelet/pki/kubelet-client-current.pem
    client-key: /var/lib/kubelet/pki/kubelet-client-current.pem
```