### PR TITLE
fix: Allow non-interactive upgrades with apt

### DIFF
--- a/infrastructure/server-setup/playbook.yml
+++ b/infrastructure/server-setup/playbook.yml
@@ -27,7 +27,8 @@
         apply:
           tags:
             - updates
-
+      tags:
+        - updates
     - include_tasks:
         file: tasks/all/users.yml
         apply:


### PR DESCRIPTION
# Description

PR addresses issue: https://github.com/opencrvs/opencrvs-core/issues/10204

Official documentation: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_module.html#parameter-dpkg_options

# Testing

## Downgrade openssh-server version

Following command performs downgrade:
```
sudo apt install openssh-server=1:9.6p1-3ubuntu13.11 \
openssh-client=1:9.6p1-3ubuntu13.11 \
openssh-sftp-server=1:9.6p1-3ubuntu13.11 \
--allow-downgrades -y
```

Make sure rollback was successful:
```
apt search openssh-server
```
Output example:
```
Sorting... Done
Full Text Search... Done
openssh-server/noble-updates 1:9.6p1-3ubuntu13.14 amd64 [upgradable from: 1:9.6p1-3ubuntu13.11]
  secure shell (SSH) server, for secure access from remote machines
```

Run provision workflow with `updates` tag:
<img width="371" height="338" alt="image" src="https://github.com/user-attachments/assets/dd88452d-5441-4993-97a6-2ec75581cf11" />

Repeat search:
```
apt search openssh-server
```
Make sure package was upgraded:
```
Sorting... Done
Full Text Search... Done
openssh-server/noble-updates,now 1:9.6p1-3ubuntu13.14 amd64 [installed]
  secure shell (SSH) server, for secure access from remote machines
```

Verify custom changes are still in sshd_config: /etc/ssh/sshd_config
```
# BEGIN ANSIBLE MANAGED BLOCK FOR USER provision
Match User provision
  PasswordAuthentication no
  AuthenticationMethods publickey
Match all
# END ANSIBLE MANAGED BLOCK FOR USER provision
```