### PR TITLE
fix: Minor changes to reset 2FA

### DIFF
--- a/.github/workflows/reset-2fa.yml
+++ b/.github/workflows/reset-2fa.yml
@@ -18,19 +18,12 @@ on:
 jobs:
   reset:
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-24.04
-    outputs:
-      outcome: ${{ steps.deploy.outcome }}
+    runs-on:
+      - self-hosted
+      - ${{ inputs.environment }}
+      - node
     timeout-minutes: 60
     steps:
-      - name: Clone country config resource package
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-          path: './${{ github.event.repository.name }}'
-      # FIXME: Reset should work on all servers
-      - name: Remove 2FA
-        run: "sudo rm /home/${{ inputs.user }}/.google_authenticator"
       - name: checkout repository
         uses: actions/checkout@v5
       - name: Run Ansible Playbook
@@ -46,5 +39,4 @@ jobs:
           # Add --verbose to get more output
           options: |-
             --inventory inventory/${{ inputs.environment }}.yml
-            ${{ inputs.tags != 'all' && format('--tags={0}', inputs.tags) || '' }}
             --extra-vars user=${{ inputs.user }}

--- a/infrastructure/server-setup/reset-2fa.yml
+++ b/infrastructure/server-setup/reset-2fa.yml
@@ -6,7 +6,6 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
----
 
 - hosts: all
   become: yes
@@ -14,5 +13,18 @@
   ignore_unreachable: false
   become_method: sudo
   tasks:
-  - name: Remove /home/${{ inputs.user }}/.google_authenticator
-    shell: rm -f /home/${{ inputs.user }}/.google_authenticator
+    - name: Check if Google Authenticator file exists
+      ansible.builtin.stat:
+        path: "/home/{{ user }}/.google_authenticator"
+      register: auth_file
+
+    - name: Show info if doesn't file exists
+      ansible.builtin.debug:
+        msg: "Google Authenticator file doesn't exist for user '{{ user }}'."
+      when: not auth_file.stat.exists
+
+    - name: Remove Google Authenticator file
+      ansible.builtin.file:
+        path: "/home/{{ user }}/.google_authenticator"
+        state: absent
+      when: auth_file.stat.exists


### PR DESCRIPTION
# Description

Addressed issue: https://github.com/opencrvs/opencrvs-core/issues/10835

Fixed bugs after initial commit: https://github.com/opencrvs/infrastructure/pull/140

# Testing

Verify file exists before running workflow:
<img width="493" height="41" alt="image" src="https://github.com/user-attachments/assets/e254ce85-eb73-4e5a-8950-48edce33289b" />

Reset 2FA: https://github.com/opencrvs/infrastructure/actions/runs/18744042153/job/53466963828
<img width="983" height="357" alt="image" src="https://github.com/user-attachments/assets/5935ec02-3940-4a82-a511-e48f947c0762" />
Reset 2FA: file doesn't exist: https://github.com/opencrvs/infrastructure/actions/runs/18744102387/job/53467156719
<img width="983" height="357" alt="image" src="https://github.com/user-attachments/assets/0497ad05-4341-4994-bc62-ff868a0be3d0" />

Reset 2FA user doesn't exist: https://github.com/opencrvs/infrastructure/actions/runs/18744135640/job/53467256530
<img width="1129" height="584" alt="image" src="https://github.com/user-attachments/assets/43a47bdf-8259-4113-96c7-c4907afa17c5" />


Ansible script should not fail, e/g If user was not provisioned on backup server, or user was not provisioned on worker nodes, but exists on master node
