### PR TITLE
feat: Document alternative ways to issue SSL certificates for traefik

### DIFF
--- a/charts/dependencies/README.md
+++ b/charts/dependencies/README.md
@@ -32,9 +32,9 @@ Any particular service within this helm chart can be disabled by setting `<servi
 | Parameter                | Type    | Default | Description                                   |
 |-|-|-|-|
 | hostname| string | farajaland.dev | All chart services will be available under specified domain. Exposed services are MinIO and Kibana, if Monitoring is enabled |
-| ingress.ssl_enabled      | bool    | false   | Enable SSL for IngressRoutes. |
+| ingress.ssl_enabled      | bool    | false   | Enable or disable https endpoint, by default all http traffic is routed to https |
 | ingress.tls_resolver | string | ` ` | If traefik was deployed with custom resolver, please define resolver name here. Resolver will be attached to Traefik CRD IngressRoute, otherwise default Traefik SSL Certificate will be used. |
-| ingress.tls_secret_name | string | ` ` | Custom SSL Certificate for IngressRoute, check traefik documentation for details |
+| ingress.tls_secret_name | string | ` ` | Secret with custom SSL Certificate for IngressRoute, check traefik documentation for details. Otherwise default Traefik SSL Certificate will be used.  |
 | storage_type | string | `pvc` | Kubernetes storage type, available options are `pvc` or `host_path`. More information are at [Storage Configuration](#storage-configuration) |
 | node_selector | dict | `{}` | Label selector for datastore nodes, usually used to keep data persistent |
 | monitoring.enabled | bool | `false` | Enable or disable monitoring, see [Monitoring](#monitoring) |

--- a/charts/opencrvs-services/README.md
+++ b/charts/opencrvs-services/README.md
@@ -270,7 +270,7 @@ helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
         <tr>
             <td>ingress.tls_secret_name</td>
             <td>` `</td>
-            <td>Custom SSL Certificate for IngressRoute, check traefik documentation for details</td>
+            <td>Secret with custom SSL Certificate for IngressRoute, check traefik documentation for details. Otherwise default Traefik SSL Certificate will be used.</td>
         </tr>
         <tr>
             <td>service_type</td>

--- a/examples/dev/README.md
+++ b/examples/dev/README.md
@@ -198,3 +198,17 @@ Data seed script also executed at the end of deployment workflow.
 Verification steps:
 - Go to login page: `https://<your domain>`
 - Login using demo users: https://documentation.opencrvs.org/setup/3.-installation/3.1-set-up-a-development-environment/3.1.4-log-in-to-opencrvs-locally
+
+
+# Advanced topics
+
+## Running traefik behind VPN
+
+### DNS Challenge
+
+Please check configuration file with example for Cloudflare at [here](./traefik/values-dns-challenge.yaml)
+
+
+### Custom SSL Certificate
+
+Please check configuration file with example for Custom SSL Certificate at [here](./traefik/values-custom-ssl.yaml)

--- a/examples/dev/traefik/README.md
+++ b/examples/dev/traefik/README.md
@@ -1,13 +1,14 @@
 
 # Install Traefik
+
+Available installation options:
+- `values.yaml`: Default lets-encrypt configuration with HTTP-01 challenge
+- `values-dns-challenge.yaml`: Lets-encrypt configuration with DNS challenge
+- `values-custom-ssl.yaml`: Custom SSL Certificate example
+
+**How to install??**
+
 ```
 helm upgrade --install traefik traefik-repo/traefik --namespace traefik --create-namespace -f values.yaml
 ```
-# Update domain name for new load balancer
-
-```
-kubectl get svc -n traefik
-```
-
-Create CNAME/A/AAA for Load balancer name. Lets encrypt works fine with CNAME.
 

--- a/examples/dev/traefik/values-custom-ssl.yaml
+++ b/examples/dev/traefik/values-custom-ssl.yaml
@@ -33,40 +33,24 @@ ports:
   web:
     port: 8000
     hostPort: 80
-    protocol: TCP
     nodePort: 30080
   websecure:
     port: 8443
     nodePort: 30443
     hostPort: 443
-    protocol: TCP
 
-certificatesResolvers:
-  letsencrypt:
-    acme:
-      tlsChallenge: false
-      httpChallenge:
-        entryPoint: web
-      email: vadym@opencrvs.org
-      # Storage for certificates:
-      storage: /certificates/acme.json
-      # NOTE: Sometimes Let's Encrypt hit production SSL certificate issuing limits
-      #       If you are having issues, switch to staging
-      # Staging server
-      # caServer: https://acme-staging-v02.api.letsencrypt.org/directory
-      # Production server
-      caServer: https://acme-v02.api.letsencrypt.org/directory
 
 deployment:
   hostNetwork: true
-  additionalVolumes:
-    - name: acme
-      hostPath:
-        path: /data/traefik
-
-additionalVolumeMounts:
-    - name: acme
-      mountPath: /certificates
 
 nodeSelector:
   traefik-role: ingress
+
+# 👇 Disable ACME
+certificatesResolvers: {}
+
+# 👇 Custom TLS configuration
+tlsStore:
+  default:
+    defaultCertificate:
+      secretName: traefik-cert

--- a/examples/dev/traefik/values-dns-challenge.yaml
+++ b/examples/dev/traefik/values-dns-challenge.yaml
@@ -41,21 +41,26 @@ ports:
     hostPort: 443
     protocol: TCP
 
+# DNS resolver configuration goes here
+# Official documentation:
+# https://doc.traefik.io/traefik/reference/install-configuration/tls/certificate-resolvers/acme/#dnschallenge
 certificatesResolvers:
-  letsencrypt:
+  cloudflare:
     acme:
-      tlsChallenge: false
-      httpChallenge:
-        entryPoint: web
-      email: vadym@opencrvs.org
-      # Storage for certificates:
+      email: vadym@opencrvs.dev
       storage: /certificates/acme.json
-      # NOTE: Sometimes Let's Encrypt hit production SSL certificate issuing limits
-      #       If you are having issues, switch to staging
-      # Staging server
-      # caServer: https://acme-staging-v02.api.letsencrypt.org/directory
-      # Production server
-      caServer: https://acme-v02.api.letsencrypt.org/directory
+      dnsChallenge:
+        provider: cloudflare
+        delayBeforeCheck: 0
+# Pass Cloudflare API token via environment variable
+env:
+  - name: CLOUDFLARE_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: cloudflare-api-token-secret
+        key: api-token
+  - name: CLOUDFLARE_EMAIL
+    value: vadym@opencrvs.dev
 
 deployment:
   hostNetwork: true

--- a/examples/dev/traefik/values.yaml
+++ b/examples/dev/traefik/values.yaml
@@ -10,17 +10,20 @@ logs:
     # -- To enable access logs
     enabled: true
     format: "json"
+
 ingressRoute:
   dashboard:
     enabled: false
+
 # Be explicit that we only use CRDs, not ingress/gw support
 providers: 
   kubernetesCRD:
     enabled: true
   kubernetesIngress:
-    enabled: true
+    enabled: false
   kubernetesGateway:
     enabled: false
+
 service:
   enabled: true
   single: false
@@ -38,9 +41,6 @@ ports:
     hostPort: 443
     protocol: TCP
 
-nodeSelector:
-  traefik-role: ingress
-
 certificatesResolvers:
   letsencrypt:
     acme:
@@ -48,31 +48,25 @@ certificatesResolvers:
       httpChallenge:
         entryPoint: web
       email: vadym@opencrvs.org
-      # Storage for production certificates:
-      # storage: /data/acme.json
-      # Storage for staging certificates:
-      storage: /data/acme-staging.json
+      # Storage for certificates:
+      storage: /certificates/acme.json
+      # NOTE: Sometimes Let's Encrypt hit production SSL certificate issuing limits
+      #       If you are having issues, switch to staging
       # Staging server
       caServer: https://acme-staging-v02.api.letsencrypt.org/directory
       # Production server
       # caServer: https://acme-v02.api.letsencrypt.org/directory
 
-# Additional arguments
-additionalArguments:
-  - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
-  - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
-  - "--certificatesresolvers.letsencrypt.acme.email=vadym@opencrvs.org"
-  # Storage for staging certificates:
-  - "--certificatesresolvers.letsencrypt.acme.storage=/data1/acme-staging.json"
-  # Storage for staging certificates:
-  # - "--certificatesresolvers.letsencrypt.acme.storage=/data/acme.json"
-
 deployment:
+  hostNetwork: true
   additionalVolumes:
     - name: acme
       hostPath:
         path: /data/traefik
 
 additionalVolumeMounts:
-  - name: acme
-    mountPath: /data1
+    - name: acme
+      mountPath: /certificates
+
+nodeSelector:
+  traefik-role: ingress


### PR DESCRIPTION
# Description

PR aims to address issues:
- https://github.com/opencrvs/opencrvs-core/issues/10879

Feature is built on top of helm pre/post-install hooks and allows to seed data only while initial opencrvs deployment