### PR TITLE
feat: Add husky branch validation

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+pattern='^[a-z][a-z0-9\/\-]{1,29}$'
+
+if [[ ! "$branch" =~ $pattern ]]; then
+  echo """
+  ❌ Invalid branch name: '$branch'
+  ➡️  Branch names must match regex: $pattern
+      - Start with a lowercase letter
+      - Can contain lowercase letters, numbers, and hyphens
+      - Length between 2 and 30 characters
+      - Slashes '/' are allowed for hierarchical branch names
+    Example: ocrvs-12345, feature-login, fix-bug123, refactor-api
+    """
+  exit 1
+fi
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "node": "22.x.x"
   },
   "license": "MPL-2.0",
-  "husky": {
-  },
+  "husky": {},
   "scripts": {
     "environment:init": "ts-node infrastructure/environments/setup-environment.ts",
-    "environment:upgrade": "yarn environment:init"
+    "environment:upgrade": "yarn environment:init",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@octokit/core": "4.2.1",


### PR DESCRIPTION
# Description

Goal of this PR is to implement restriction on git branch names: https://github.com/opencrvs/opencrvs-core/issues/9816

Branch name is limited to 30 characters due to helm release name limitations 53 characters.

NOTE: 30 characters length is the restriction increased a while ago for docker (https://github.com/moby/moby/pull/11118)

# Testing

## Failed examples
<img width="739" height="168" alt="image" src="https://github.com/user-attachments/assets/2339dfc1-c9a9-4d9a-8bd1-95330fd588e8" />

<img width="716" height="145" alt="image" src="https://github.com/user-attachments/assets/5027b875-475c-495d-b959-89147d6594f3" />

<img width="969" height="180" alt="image" src="https://github.com/user-attachments/assets/d6bd43a7-f697-4708-9f84-8e149c26a816" />

## Success examples
<img width="742" height="148" alt="image" src="https://github.com/user-attachments/assets/6b31e134-16c8-4401-9b64-d4da1add4310" />

<img width="729" height="139" alt="image" src="https://github.com/user-attachments/assets/e841bce8-350d-420b-840f-6eee1af02da1" />
