### PR TITLE
feat: Add re-index cronjob to OpenCRVS helm chart

### DIFF
--- a/.github/TEMPLATES/secret-mapping-deps.yml
+++ b/.github/TEMPLATES/secret-mapping-deps.yml
@@ -1,4 +1,3 @@
-# FIXME: Once real values are populated drop `tmp` suffix
 backup-encryption-secret:
   # This is the password that is used to encrypt all the backups that OpenCRVS creates from
   # a production server and that are stored on the backup server. Use this passphrase to decrypt the backups.

--- a/.github/TEMPLATES/secret-mapping-opencrvs.yml
+++ b/.github/TEMPLATES/secret-mapping-opencrvs.yml
@@ -1,4 +1,3 @@
-# FIXME: Once real values are populated drop `tmp` suffix
 dashboards-admin-user:
   # Email address for metabase admin panel login
   - OPENCRVS_METABASE_ADMIN_EMAIL

--- a/charts/opencrvs-services/Chart.yaml
+++ b/charts/opencrvs-services/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrvs-services
 description: OpenCRVS Services
 type: application
-version: 0.1.18
+version: 0.1.19
 appVersion: 1.9.0

--- a/charts/opencrvs-services/README.md
+++ b/charts/opencrvs-services/README.md
@@ -85,6 +85,16 @@ helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
             <td>Elasticsearch port.</td>
         </tr>
         <tr>
+            <td>elasticsearch.reindex.enabled</td>
+            <td>false</td>
+            <td>Enable elasticsearch reindex job. Required if database restore is configured.</td>
+        </tr>
+        <tr>
+            <td>elasticsearch.reindex.schedule</td>
+            <td><pre>0 2 * * *</pre></td>
+            <td>Schedule time for cronjob. Make sure reindex doesn't overlap with database restore job.</td>
+        </tr>
+        <tr>
             <td>elasticsearch.auth_mode</td>
             <td>disabled</td>
             <td>  Following values are allowed

--- a/charts/opencrvs-services/templates/_reindex-helper.tpl
+++ b/charts/opencrvs-services/templates/_reindex-helper.tpl
@@ -1,0 +1,25 @@
+{{- define "elasticsearch-reindex.podSpec" -}}
+  template:
+    metadata:
+      labels:
+        app: elasticsearch-reindex
+    spec:
+      containers:
+        - name: elasticsearch-reindex
+          command: ["sh", "-c", "apk add --no-cache curl jq && /scripts/reindex.sh"]
+          image: "alpine"
+          env:
+            - name: AUTH_URL
+              value: "http://auth.{{ .Release.Namespace }}.svc.cluster.local:4040"
+            - name: EVENTS_URL
+              value: "http://events.{{ .Release.Namespace }}.svc.cluster.local:5555"
+          volumeMounts:
+            - mountPath: /scripts
+              name: elasticsearch-reindex-script
+      volumes:
+        - name: elasticsearch-reindex-script
+          configMap:
+            name: elasticsearch-reindex-script
+            defaultMode: 0755
+      restartPolicy: "OnFailure"
+{{- end }}

--- a/charts/opencrvs-services/templates/elasticsearch-reindex-job.yaml
+++ b/charts/opencrvs-services/templates/elasticsearch-reindex-job.yaml
@@ -13,21 +13,18 @@ spec:
       labels:
         app: elasticsearch-reindex
     spec:
-      containers:
-        - name: elasticsearch-reindex
-          command: ["sh", "-c", "apk add --no-cache curl jq && /scripts/reindex.sh"]
-          image: "alpine"
-          env:
-            - name: AUTH_URL
-              value: "http://auth.{{ .Release.Namespace }}.svc.cluster.local:4040"
-            - name: EVENTS_URL
-              value: "http://events.{{ .Release.Namespace }}.svc.cluster.local:5555"
-          volumeMounts:
-            - mountPath: /scripts
-              name: elasticsearch-reindex-script
-      volumes:
-        - name: elasticsearch-reindex-script
-          configMap:
-            name: elasticsearch-reindex-script
-            defaultMode: 0755
-      restartPolicy: "OnFailure"
+{{ include "elasticsearch-reindex.podSpec" . | indent 2 }}
+
+{{- if .Values.elasticsearch.reindex.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels:
+    app: elasticsearch
+  name: elasticsearch-reindex
+spec:
+  schedule: "{{ .Values.elasticsearch.reindex.schedule }}"
+  jobTemplate:
+    spec:
+{{ include "elasticsearch-reindex.podSpec" . | indent 6 }}
+{{- end }}

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -16,7 +16,9 @@
 elasticsearch:
   host: elasticsearch.opencrvs-deps-dev.svc.cluster.local
   port: 9200
-
+  reindex:
+    enabled: false
+    schedule: "0 2 * * *"
   # auth_mode:
   # - disabled: No authentication enabled for MongoDB, password-less access to databases
   # - auto: Users are managed by OpenCRVS helm chart, this mode requires secret to be created with MongoDB admin user


### PR DESCRIPTION
This PR aims to add re-index by cron to OpenCRVS helm chart and partially address issue: https://github.com/opencrvs/opencrvs-core/issues/11044

# Manual testing

Values file with reindex enabled was created by `helm get values opencrvs`, see attached file. Code snippet:
```yaml
elasticsearch:
  reindex:
    enabled: true
  auth_mode: auto
  host: elasticsearch.opencrvs-deps-staging.svc.cluster.local
```

Helm chart was deployed manually:
<img width="773" height="120" alt="image" src="https://github.com/user-attachments/assets/c381bf48-d930-45da-bc3e-06929d237d01" />

Cronjob was created and manually ran:

<img width="933" height="88" alt="image" src="https://github.com/user-attachments/assets/a72a0ded-39be-4b1f-bcaa-364844f9f2ea" />

Re-index completed without issues:
<img width="763" height="330" alt="image" src="https://github.com/user-attachments/assets/238914e9-72ee-4760-b56c-57b36e5f5fe2" />

All data from production was properly displayed on staging:
<img width="1891" height="1012" alt="image" src="https://github.com/user-attachments/assets/c98b03e6-a21d-4e5f-bfb3-7a27f5725f06" />
