### PR TITLE
fix: Swap was not disabled by provision script

### DIFF
--- a/infrastructure/server-setup/tasks/k8s/install-kubernetes.yml
+++ b/infrastructure/server-setup/tasks/k8s/install-kubernetes.yml
@@ -16,11 +16,18 @@
 - name: Add Kubernetes APT repository
   shell: echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{ kubernetes_version }}/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list
 
-- name: Update apt cache and install Kubernetes components
-  shell: apt-get update && apt-get install -y kubelet kubeadm kubectl
-
-- name: Hold Kubernetes packages
-  shell: apt-mark hold kubelet kubeadm kubectl
+- name: Install specific Kubernetes version
+  become: yes
+  ansible.builtin.apt:
+    update_cache: yes
+    name:
+      - kubelet
+      - kubeadm
+      - kubectl
+    state: present
 
 - name: Enable kubelet service
-  shell: systemctl enable kubelet
+  become: yes
+  ansible.builtin.systemd:
+    name: kubelet
+    enabled: yes

--- a/infrastructure/server-setup/tasks/k8s/system-preparation.yml
+++ b/infrastructure/server-setup/tasks/k8s/system-preparation.yml
@@ -1,8 +1,12 @@
 - name: Disable swap
   shell: swapoff -a
   
-- name: Remove swap from fstab
-  shell: sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
+- name: Comment active swap entries in fstab
+  ansible.builtin.replace:
+    path: /etc/fstab
+    regexp: '^([^#].*[ \t]swap[ \t].*)$'
+    replace: '# \1'
+    backup: yes
 
 - name: Load required kernel modules
   shell: |


### PR DESCRIPTION

This fix aims to address the issue with swap definition in /etc/fstab surrounded by `tabs`: https://github.com/opencrvs/opencrvs-core/issues/11086


**Included fix: Allow patch version upgrades**

Related pipeline: https://github.com/opencrvs/infrastructure/actions/runs/19634422352/job/56221598623
<img width="1488" height="386" alt="image" src="https://github.com/user-attachments/assets/6e8dca0a-741a-4cfc-8a16-ea2a2846fd35" />

# Testing

## Disable swap testing
Dummy entry was created with combination of `tab` and `space`:
<img width="648" height="218" alt="image" src="https://github.com/user-attachments/assets/ae26ae77-ccd6-4407-9e6b-0b36c7d41625" />

After running provision job: https://github.com/opencrvs/infrastructure/actions/runs/19635610498
<img width="547" height="215" alt="image" src="https://github.com/user-attachments/assets/2a7e4dea-992c-4598-88a7-2c9bc3af5b09" />

NOTE: Provision script was ran multiple times to check stability


## Patch version upgrade testing

Related pipeline: https://github.com/opencrvs/infrastructure/actions/runs/19634954096/job/56223314029
<img width="1190" height="81" alt="image" src="https://github.com/user-attachments/assets/3fa38941-a90b-4a90-a65f-634ed58ad33c" />

