### PR TITLE
fix: Adjust traefik default settings

### DIFF
--- a/examples/dev/traefik/values-custom-ssl.yaml
+++ b/examples/dev/traefik/values-custom-ssl.yaml
@@ -33,18 +33,19 @@ ports:
   web:
     port: 8000
     hostPort: 80
+    protocol: TCP
     nodePort: 30080
+    redirections:
+      entryPoint:
+        to: websecure
+        scheme: https
+        permanent: true
+
   websecure:
     port: 8443
-    nodePort: 30443
     hostPort: 443
-
-
-deployment:
-  hostNetwork: true
-
-nodeSelector:
-  traefik-role: ingress
+    protocol: TCP
+    nodePort: 30443
 
 # 👇 Disable ACME
 certificatesResolvers: {}
@@ -53,4 +54,12 @@ certificatesResolvers: {}
 tlsStore:
   default:
     defaultCertificate:
+      # Check documentation how to create secret with static SSL certificate
       secretName: traefik-cert
+
+
+deployment:
+  hostNetwork: true
+
+nodeSelector:
+  traefik-role: ingress

--- a/examples/dev/traefik/values-dns-challenge.yaml
+++ b/examples/dev/traefik/values-dns-challenge.yaml
@@ -35,11 +35,21 @@ ports:
     hostPort: 80
     protocol: TCP
     nodePort: 30080
+    redirections:
+      entryPoint:
+        to: websecure
+        scheme: https
+        permanent: true
+
   websecure:
     port: 8443
-    nodePort: 30443
     hostPort: 443
     protocol: TCP
+    nodePort: 30443
+    # 👇 Adjust this section at websecure entrypoint
+    tls:
+      enabled: true
+      certResolver: cloudflare
 
 # DNS resolver configuration goes here
 # Official documentation:
@@ -47,7 +57,8 @@ ports:
 certificatesResolvers:
   cloudflare:
     acme:
-      email: vadym@opencrvs.dev
+      # 👇 Provide admin email address
+      email: admin@opencrvs.org
       storage: /certificates/acme.json
       dnsChallenge:
         provider: cloudflare

--- a/examples/dev/traefik/values.yaml
+++ b/examples/dev/traefik/values.yaml
@@ -35,19 +35,31 @@ ports:
     hostPort: 80
     protocol: TCP
     nodePort: 30080
+    redirections:
+      entryPoint:
+        to: websecure
+        scheme: https
+        permanent: true
+
   websecure:
     port: 8443
-    nodePort: 30443
     hostPort: 443
     protocol: TCP
+    nodePort: 30443
+    # 👇 Adjust this section at websecure entrypoint
+    tls:
+      enabled: true
+      certResolver: letsencrypt
 
+# 👇 Adjust this section if needed
 certificatesResolvers:
   letsencrypt:
     acme:
       tlsChallenge: false
       httpChallenge:
         entryPoint: web
-      email: vadym@opencrvs.org
+      # 👇 Provide admin email address
+      email: admin@opencrvs.org
       # Storage for certificates:
       storage: /certificates/acme.json
       # NOTE: Sometimes Let's Encrypt hit production SSL certificate issuing limits

--- a/infrastructure/environments/templates/charts-values/dependencies/values.yaml
+++ b/infrastructure/environments/templates/charts-values/dependencies/values.yaml
@@ -2,9 +2,6 @@ storage_type: host_path
 
 environment_type: {{environment_type}}
 
-ingress:
-  tls_resolver: letsencrypt
-
 minio:
   use_default_credentials: false
 

--- a/infrastructure/environments/templates/charts-values/opencrvs-services/values.yaml
+++ b/infrastructure/environments/templates/charts-values/opencrvs-services/values.yaml
@@ -6,9 +6,6 @@
 # - hostname: valid DNS name for opencrvs
 # - countryconfig.image.name: Countryconfig image repository
 # - countryconfig.image.tag: Countryconfig image tag
-ingress:
-  tls_resolver: letsencrypt
-
 environment_type: {{environment_type}}
 
 hpa:

--- a/infrastructure/environments/templates/charts-values/traefik/values.yaml
+++ b/infrastructure/environments/templates/charts-values/traefik/values.yaml
@@ -35,19 +35,31 @@ ports:
     hostPort: 80
     protocol: TCP
     nodePort: 30080
+    redirections:
+      entryPoint:
+        to: websecure
+        scheme: https
+        permanent: true
+
   websecure:
     port: 8443
-    nodePort: 30443
     hostPort: 443
     protocol: TCP
+    nodePort: 30443
+    # 👇 Adjust this section at websecure entrypoint
+    tls:
+      enabled: true
+      certResolver: letsencrypt
 
+# 👇 Adjust this section if needed
 certificatesResolvers:
   letsencrypt:
     acme:
       tlsChallenge: false
       httpChallenge:
         entryPoint: web
-      email: vadym@opencrvs.org
+      # 👇 Provide admin email address
+      email: admin@opencrvs.org
       # Storage for certificates:
       storage: /certificates/acme.json
       # NOTE: Sometimes Let's Encrypt hit production SSL certificate issuing limits


### PR DESCRIPTION
# Description

This PR is going to address following issue: https://github.com/opencrvs/opencrvs-core/issues/11127

Improvements:
- Permanents redirect from http to https
- Set default resolver for websecure entrypoint as a result no need to define certificate resolver for OpenCRVS and dependencies helm charts
- Updated examples

# Testing

Testing was performed on custom branch: https://github.com/opencrvs/infrastructure/tree/demo1-testing

Deployed environment: https://tmp-prod.opencrvs.dev/

Certificate was issued with letsencrypt:
<img width="1432" height="713" alt="image" src="https://github.com/user-attachments/assets/6dc1590f-0702-484e-b5aa-b9d48e4d29c1" />

No resolver pointed in helm chart: https://github.com/opencrvs/infrastructure/commit/36c0c0dbf776ff56163eff3659face77be02c984
