### PR TITLE
feat: add EVENTS_MIGRATION_USER to postgres data migration job

### DIFF
--- a/charts/opencrvs-services/templates/postgres-data-migration-job.yaml
+++ b/charts/opencrvs-services/templates/postgres-data-migration-job.yaml
@@ -125,6 +125,11 @@ spec:
                 secretKeyRef:
                   key: EVENTS_APP_POSTGRES_USER
                   name: {{ .Values.postgres.users_secret }}
+            - name: EVENTS_MIGRATION_USER
+              valueFrom:
+                secretKeyRef:
+                  key: EVENTS_MIGRATOR_POSTGRES_USER
+                  name: {{ .Values.postgres.users_secret }}
           {{- end }}
 
           {{- if or (eq .Values.minio.auth_mode "auto") (eq .Values.minio.auth_mode "use_secret") }}


### PR DESCRIPTION
We are adding the `EVENTS_MIGRATION_USER` environment variable to the data migration job as part of https://github.com/opencrvs/opencrvs-core/pull/11048.