### PR TITLE
fix: Move analytics user creation to on-deploy script

### DIFF
--- a/charts/opencrvs-services/files/postgres-on-deploy.sh
+++ b/charts/opencrvs-services/files/postgres-on-deploy.sh
@@ -13,13 +13,38 @@ set -euo pipefail
 : "${POSTGRES_PASSWORD:?Must set POSTGRES_PASSWORD}"
 : "${EVENTS_MIGRATOR_POSTGRES_PASSWORD:?Must set EVENTS_MIGRATOR_POSTGRES_PASSWORD}"
 : "${EVENTS_APP_POSTGRES_PASSWORD:?Must set EVENTS_APP_POSTGRES_PASSWORD}"
+: "${ANALYTICS_POSTGRES_PASSWORD:?Must set ANALYTICS_POSTGRES_PASSWORD}"
+: "${ANALYTICS_POSTGRES_USER:?Must set ANALYTICS_POSTGRES_USER}"
 : "${EVENTS_APP_ROLE:=events_app}"
 : "${EVENTS_MIGRATOR_ROLE:=events_migrator}"
+: "${KEEP_ALIVE_SECONDS:=0}" # Prevent Swarm from marking this task as failed due to early exit
 : "${TARGET_DB:=events}"
 
 
 TARGET_DB=${TARGET_DB//-/_}
 export PGPASSWORD="$POSTGRES_PASSWORD"
+
+
+create_or_update_role() {
+  local role=$1
+  local password=$2
+  local db=$3
+  echo "Creating or updating role '$role' with access to database '$db'..."
+  PGPASSWORD="$POSTGRES_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
+    -U "$POSTGRES_USER" -d postgres <<EOSQL
+DO \$\$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${role}') THEN
+    EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', '${role}', '${password}');
+  ELSE
+    EXECUTE format('ALTER ROLE %I WITH PASSWORD %L', '${role}', '${password}');
+  END IF;
+
+  EXECUTE format('GRANT CONNECT ON DATABASE %I TO %I', '${db}', '${role}');
+END
+\$\$;
+EOSQL
+}
 
 echo "Waiting for PostgreSQL to be ready at ${POSTGRES_HOST}:${POSTGRES_PORT}..."
 until psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
@@ -35,59 +60,18 @@ DB_EXISTS=$(psql -qtAX -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
   -U "$POSTGRES_USER" -d postgres \
   -c "SELECT 1 FROM pg_database WHERE datname = '$TARGET_DB';")
 
-# --- Check role existence ---
-MIGRATOR_ROLE_EXISTS=$(
-  psql -qtAX -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
-    -U "$POSTGRES_USER" -d postgres \
-    -c "SELECT 1 FROM pg_roles WHERE rolname = '${EVENTS_MIGRATOR_ROLE}';"
-)
-APP_ROLE_EXISTS=$(
-  psql -qtAX -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
-    -U "$POSTGRES_USER" -d postgres \
-    -c "SELECT 1 FROM pg_roles WHERE rolname = '${EVENTS_APP_ROLE}';"
-)
-
 echo "[1/3] Cluster-wide setup..."
 if [[ "$DB_EXISTS" == "1" ]]; then
-  echo "✅ Database '$TARGET_DB' already exists. Updating passwords."
-  # Create roles if missing, alter password if they exist
-  if [ "$MIGRATOR_ROLE_EXISTS" != "1" ]; then
-    echo "Creating role ${EVENTS_MIGRATOR_ROLE}..."
-    psql -v ON_ERROR_STOP=1 -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
-      -U "$POSTGRES_USER" -d postgres \
-      -c "CREATE ROLE ${EVENTS_MIGRATOR_ROLE} WITH LOGIN PASSWORD '${EVENTS_MIGRATOR_POSTGRES_PASSWORD}';"
-  else
-    echo "ALTERING password for ${EVENTS_MIGRATOR_ROLE}..."
-    psql -v ON_ERROR_STOP=1 -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
-      -U "$POSTGRES_USER" -d postgres \
-      -c "ALTER ROLE ${EVENTS_MIGRATOR_ROLE} WITH PASSWORD '${EVENTS_MIGRATOR_POSTGRES_PASSWORD}';"
-  fi
-
-  if [ "$APP_ROLE_EXISTS" != "1" ]; then
-    echo "Creating role ${EVENTS_APP_ROLE}..."
-    psql -v ON_ERROR_STOP=1 -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
-      -U "$POSTGRES_USER" -d postgres \
-      -c "CREATE ROLE ${EVENTS_APP_ROLE} WITH LOGIN PASSWORD '${EVENTS_APP_POSTGRES_PASSWORD}';"
-  else
-    echo "ALTERING password for ${EVENTS_APP_ROLE}..."
-    psql -v ON_ERROR_STOP=1 -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
-      -U "$POSTGRES_USER" -d postgres \
-      -c "ALTER ROLE ${EVENTS_APP_ROLE} WITH PASSWORD '${EVENTS_APP_POSTGRES_PASSWORD}';"
-  fi
-
-  echo "Passwords updated. Skipping initialization."
+  echo "✅ Database '$TARGET_DB' already exists."
 else
   echo "Database '$TARGET_DB' does not exist. Proceeding with initialization."
-  psql -v ON_ERROR_STOP=1 -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
-  -U "$POSTGRES_USER" -d postgres <<EOF || { echo "❌ Cluster-wide SQL failed"; exit 1; }
-CREATE DATABASE "$TARGET_DB";
-
-CREATE ROLE ${EVENTS_MIGRATOR_ROLE} WITH LOGIN PASSWORD '${EVENTS_MIGRATOR_POSTGRES_PASSWORD}';
-CREATE ROLE ${EVENTS_APP_ROLE} WITH LOGIN PASSWORD '${EVENTS_APP_POSTGRES_PASSWORD}';
-
-GRANT CONNECT ON DATABASE "$TARGET_DB" TO ${EVENTS_MIGRATOR_ROLE}, ${EVENTS_APP_ROLE};
-EOF
+  psql -v ON_ERROR_STOP=1 -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d postgres \
+       -c "CREATE DATABASE ${TARGET_DB};" || echo "❌ Cluster-wide SQL failed"; exit 1;
 fi
+
+create_or_update_role "$EVENTS_MIGRATOR_ROLE" "$EVENTS_MIGRATOR_POSTGRES_PASSWORD" "$TARGET_DB"
+create_or_update_role "$EVENTS_APP_ROLE" "$EVENTS_APP_POSTGRES_PASSWORD" "$TARGET_DB"
+create_or_update_role "$ANALYTICS_POSTGRES_USER" "$ANALYTICS_POSTGRES_PASSWORD" "$TARGET_DB"
 
 echo "Checking if schema app in DB '$TARGET_DB' exists..."
 SCHEMA_EXISTS=$(psql -qtAX -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
@@ -114,5 +98,7 @@ GRANT USAGE ON SCHEMA app TO ${EVENTS_APP_ROLE};
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA app TO ${EVENTS_APP_ROLE};
 ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ${EVENTS_APP_ROLE};
 EOF
+
+sleep "$KEEP_ALIVE_SECONDS"
 
 echo "✅ PostgreSQL setup completed successfully."

--- a/charts/opencrvs-services/files/setup-analytics.sh
+++ b/charts/opencrvs-services/files/setup-analytics.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 : "${POSTGRES_PORT:=5432}"
 : "${POSTGRES_PASSWORD:?Must set POSTGRES_PASSWORD}"
 : "${POSTGRES_USER:?Must set POSTGRES_USER}"
-: "${ANALYTICS_POSTGRES_PASSWORD:?Must set ANALYTICS_POSTGRES_PASSWORD}"
 : "${ANALYTICS_POSTGRES_USER:?Must set ANALYTICS_POSTGRES_USER}"
 : "${KEEP_ALIVE_SECONDS:=0}" # Prevent Swarm from marking this task as failed due to early exit
 : "${TARGET_DB:=events}"
@@ -18,31 +17,6 @@ until PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$POSTGRES_HOST" -p "$POSTGRES_POR
   -U "$POSTGRES_USER" -d postgres -c '\q' 2>/dev/null; do
   sleep 2
 done
-
-sleep "$KEEP_ALIVE_SECONDS"
-
-create_or_update_role() {
-  local role=$1
-  local password=$2
-  local db=$3
-  echo "Creating or updating role '$role' with access to database '$db'..."
-  PGPASSWORD="$POSTGRES_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
-    -U "$POSTGRES_USER" -d postgres <<EOSQL
-DO \$\$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${role}') THEN
-    EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', '${role}', '${password}');
-  ELSE
-    EXECUTE format('ALTER ROLE %I WITH PASSWORD %L', '${role}', '${password}');
-  END IF;
-
-  EXECUTE format('GRANT CONNECT ON DATABASE %I TO %I', '${db}', '${role}');
-END
-\$\$;
-EOSQL
-}
-
-create_or_update_role "$ANALYTICS_POSTGRES_USER" "$ANALYTICS_POSTGRES_PASSWORD" "$TARGET_DB"
 
 # Schema + tables + grants
 PGPASSWORD="$POSTGRES_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \


### PR DESCRIPTION
# Testing

## On existing database

```
helm upgrade -f opencrvs.yaml opencrvs charts/opencrvs-services/
Release "opencrvs" has been upgraded. Happy Helming!
NAME: opencrvs
LAST DEPLOYED: Fri Nov 28 11:13:13 2025
NAMESPACE: opencrvs-staging
STATUS: deployed
REVISION: 27
TEST SUITE: None
```

<img width="721" height="482" alt="image" src="https://github.com/user-attachments/assets/269452dc-7cc2-4fba-a0b8-ee61085d5739" />

## Database reset

https://github.com/opencrvs/infrastructure/actions/runs/19759350804

<img width="969" height="551" alt="image" src="https://github.com/user-attachments/assets/137521ec-8f0a-40f1-8e75-1e750f86aa95" />

