### PR TITLE
feat: Add post-deploy email support

### DIFF
--- a/.github/workflows/deploy-dependencies.yml
+++ b/.github/workflows/deploy-dependencies.yml
@@ -46,6 +46,7 @@ jobs:
       - ${{ inputs.environment }}
     env:
       ENV: ${{ inputs.environment }}
+      GITHUB_ACTOR: ${{ github.actor }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -58,6 +59,7 @@ jobs:
             -f environments/${ENV}/traefik/values.yaml
           kubectl scale deployment traefik --replicas=1 --namespace traefik
       - name: Install OpenCRVS dependencies
+        id: deploy
         run: |
           helm upgrade --install opencrvs-deps oci://ghcr.io/opencrvs/opencrvs-dependencies-chart \
             --namespace "opencrvs-deps-${ENV}" \
@@ -66,3 +68,20 @@ jobs:
             --timeout 15m \
             --set hostname=${{ vars.DOMAIN }} \
             --atomic
+      - name: Send email
+        if: always()
+        run: |
+          subject="🚀 OpenCRVS dependencies deployment to '$ENV' completed successfully"
+          if [ "${{ steps.deploy.outcome }}" == 'failure' ]; then
+            subject="⚠️ OpenCRVS deployment to '$ENV' has failed"
+          fi
+          EMAIL_PAYLOAD="{
+            \"subject\": \"$subject\",
+            \"html\": \"${subject}<br/>Deployed by GitHub user: @${GITHUB_ACTOR}\",
+            \"from\": \"${SENDER_EMAIL_ADDRESS}\",
+            \"to\": \"${ALERT_EMAIL}\"
+          }"
+
+          curl -X POST http://countryconfig.opencrvs-$ENV.svc.cluster.local:3040/email \
+               -H 'Content-Type: application/json' \
+               -d "$EMAIL_PAYLOAD"

--- a/.github/workflows/deploy-opencrvs.yml
+++ b/.github/workflows/deploy-opencrvs.yml
@@ -63,9 +63,12 @@ jobs:
     env:
       ENV: ${{ inputs.environment }}
       BRANCH: ${{ github.ref_name }}
+      GITHUB_ACTOR: ${{ github.actor }}
       CORE_IMAGE_TAG: ${{ inputs.core-image-tag }}
       COUNTRYCONFIG_IMAGE_TAG: ${{ inputs.countryconfig-image-tag }}
       COUNTRYCONFIG_IMAGE_NAME: ${{ secrets.DOCKERHUB_ACCOUNT || 'opencrvs' }}/${{ secrets.DOCKERHUB_REPO || 'ocrvs-farajaland'}}
+      SENDER_EMAIL_ADDRESS: ${{ secrets.SENDER_EMAIL_ADDRESS }}
+      ALERT_EMAIL: ${{ secrets.ALERT_EMAIL }}
     runs-on:
       - self-hosted
       - k8s
@@ -111,6 +114,7 @@ jobs:
             || echo "Secret $secret doesn't exist in opencrvs-deps-${ENV} namespace"
           done
       - name: Deploy with Helm
+        id: deploy
         run: |
           helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
             --timeout 15m \
@@ -132,3 +136,21 @@ jobs:
           jq -r '.items[] | select(.metadata.labels.status=="pending-install" or .metadata.labels.status=="pending-upgrade" or .metadata.labels.status=="pending-rollback") | .metadata.name' | \
           xargs -r kubectl -n "opencrvs-${ENV}" delete secret || \
           echo "No helm locks found, all is good"
+      - name: Send email
+        if: always()
+        run: |
+          echo "OpenCRVS deployment status: ${{ steps.deploy.outcome }}"
+          subject="🚀 OpenCRVS deployment to '$ENV' completed successfully"
+          if [ "${{ steps.deploy.outcome }}" == 'failure' ]; then
+            subject="⚠️ OpenCRVS deployment to '$ENV' has failed"
+          fi
+          EMAIL_PAYLOAD="{
+            \"subject\": \"$subject\",
+            \"html\": \"${subject} with images '$CORE_IMAGE_TAG' for core and '$COUNTRYCONFIG_IMAGE_TAG' for country config.<br/>Deployed by GitHub user: @${GITHUB_ACTOR}\",
+            \"from\": \"${SENDER_EMAIL_ADDRESS}\",
+            \"to\": \"${ALERT_EMAIL}\"
+          }"
+
+          curl -X POST http://countryconfig.opencrvs-$ENV.svc.cluster.local:3040/email \
+               -H 'Content-Type: application/json' \
+               -d "$EMAIL_PAYLOAD"


### PR DESCRIPTION
Addressed issue: https://github.com/opencrvs/opencrvs-core/issues/11219

# Testing

Successful deployment email:
<img width="1003" height="260" alt="image" src="https://github.com/user-attachments/assets/bb7a29f9-2cce-4ffe-ba96-e48750eaf81a" />

Failed email example:
<img width="1090" height="362" alt="image" src="https://github.com/user-attachments/assets/b2fb1ec0-9f75-4b0c-a22e-f2beeb830277" />
