### PR TITLE
feat(ocrvs-10450): postgres migration changes for mongo fdw

### DIFF
--- a/charts/dependencies/Chart.yaml
+++ b/charts/dependencies/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrvs-dependencies-chart
 description: Dependencies required by OpenCRVS
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: 1.9.0

--- a/charts/dependencies/templates/postgres-backup-cronjob.yaml
+++ b/charts/dependencies/templates/postgres-backup-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: backup
-              image: postgres:17
+              image: docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2
               env:
                 - name: POSTGRES_HOST
                   value: postgres-0.postgres.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/dependencies/templates/postgres-restore-cronjob.yaml
+++ b/charts/dependencies/templates/postgres-restore-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: restore
-              image: postgres:17
+              image: docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2
               env:
                 - name: POSTGRES_HOST
                   value: postgres-0.postgres.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/dependencies/templates/postgres.yaml
+++ b/charts/dependencies/templates/postgres.yaml
@@ -64,7 +64,7 @@ spec:
             {{- end }}
       {{- end }}
       containers: 
-        - image: postgres:17
+        - image: docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2
           name: postgres
           env:
           {{- if .Values.postgres.use_default_credentials }}

--- a/charts/opencrvs-services/Chart.yaml
+++ b/charts/opencrvs-services/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrvs-services
 description: OpenCRVS Services
 type: application
-version: 0.1.19
+version: 0.1.20
 appVersion: 1.9.0

--- a/charts/opencrvs-services/templates/data-cleanup-job.yaml
+++ b/charts/opencrvs-services/templates/data-cleanup-job.yaml
@@ -50,7 +50,7 @@ spec:
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "data_cleanup" "Values" .Values) }}
         - name: cleanup-postgres
-          image: postgres:17
+          image: docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2
           command: ["/bin/bash", "-c"]
           args:
             - |

--- a/charts/opencrvs-services/templates/data-migration-job.yaml
+++ b/charts/opencrvs-services/templates/data-migration-job.yaml
@@ -103,10 +103,20 @@ spec:
                 secretKeyRef:
                   key: events_migrator_db_url
                   name: {{ .Values.postgres.urls_secret }}
+            - name: EVENTS_SUPERUSER_POSTGRES_URL
+              valueFrom:
+                secretKeyRef:
+                  key: events_superuser_db_url
+                  name: {{ .Values.postgres.urls_secret }}
             - name: EVENTS_DB_USER
               valueFrom:
                 secretKeyRef:
                   key: EVENTS_APP_POSTGRES_USER
+                  name: {{ .Values.postgres.users_secret }}
+            - name: EVENTS_MIGRATION_USER
+              valueFrom:
+                secretKeyRef:
+                  key: EVENTS_MIGRATOR_POSTGRES_USER
                   name: {{ .Values.postgres.users_secret }}
           {{- end }}
 

--- a/charts/opencrvs-services/templates/postgres-on-update-analytics-job.yaml
+++ b/charts/opencrvs-services/templates/postgres-on-update-analytics-job.yaml
@@ -18,7 +18,7 @@ spec:
         - name: postgres-on-update-analytics
           command: ["bash", "-c", "/scripts/setup-analytics.sh"]
           # command: ["bash", "-c", "/scripts/on-deploy.sh;"]
-          image: "postgres:17"
+          image: "docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2"
           env:
             - name: POSTGRES_HOST
               value: {{ .Values.postgres.host }}

--- a/charts/opencrvs-services/templates/postgres-on-update-analytics-job.yaml
+++ b/charts/opencrvs-services/templates/postgres-on-update-analytics-job.yaml
@@ -18,7 +18,7 @@ spec:
         - name: postgres-on-update-analytics
           command: ["bash", "-c", "/scripts/setup-analytics.sh"]
           # command: ["bash", "-c", "/scripts/on-deploy.sh;"]
-          image: "docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2"
+          image: docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2
           env:
             - name: POSTGRES_HOST
               value: {{ .Values.postgres.host }}

--- a/charts/opencrvs-services/templates/postgres-on-update-core-job.yaml
+++ b/charts/opencrvs-services/templates/postgres-on-update-core-job.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: postgres-on-update-core
           command: ["bash", "-c", "/scripts/on-deploy.sh"]
-          image: "docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2"
+          image: docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2
           env:
             - name: POSTGRES_HOST
               value: {{ .Values.postgres.host }}

--- a/charts/opencrvs-services/templates/postgres-on-update-core-job.yaml
+++ b/charts/opencrvs-services/templates/postgres-on-update-core-job.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: postgres-on-update-core
           command: ["bash", "-c", "/scripts/on-deploy.sh"]
-          image: "postgres:17"
+          image: "docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2"
           env:
             - name: POSTGRES_HOST
               value: {{ .Values.postgres.host }}

--- a/charts/opencrvs-services/templates/postgres-secrets.yaml
+++ b/charts/opencrvs-services/templates/postgres-secrets.yaml
@@ -4,6 +4,14 @@
 {{- $passwords := dict }}
 {{- $postgres_db_urls := dict }}
 
+{{- $POSTGRES_USER := "postgres" }}
+{{- $POSTGRES_PASSWORD := "postgres" }}
+
+{{- $postgres_admin_secret := lookup "v1" "Secret" .Release.Namespace .Values.postgres.admin_user_secret_name }}
+{{- if $postgres_admin_secret }}
+  {{- $POSTGRES_USER = (index $postgres_admin_secret.data "POSTGRES_USER" | b64dec) }}
+  {{- $POSTGRES_PASSWORD = (index $postgres_admin_secret.data "POSTGRES_PASSWORD" | b64dec) }}
+{{- end }}
 
 {{- $EVENTS_APP_POSTGRES_PASSWORD := randAlphaNum 32 }}
 {{- $EVENTS_MIGRATOR_POSTGRES_PASSWORD := randAlphaNum 32 }}
@@ -25,6 +33,7 @@
 {{- $EVENTS_DB := $.Values.postgres.events_db | replace "-" "_" }}
 {{- $_ := set $postgres_db_urls "events_app_db_url" (printf "postgres://%s:%s@%s:5432/%s" $EVENTS_APP_POSTGRES_USER $EVENTS_APP_POSTGRES_PASSWORD $.Values.postgres.host $EVENTS_DB) }}
 {{- $_ := set $postgres_db_urls "events_migrator_db_url" (printf "postgres://%s:%s@%s:5432/%s" $EVENTS_MIGRATOR_POSTGRES_USER $EVENTS_MIGRATOR_POSTGRES_PASSWORD $.Values.postgres.host $EVENTS_DB) }}
+{{- $_ := set $postgres_db_urls "events_superuser_db_url" (printf "postgres://%s:%s@%s:5432/%s" $POSTGRES_USER $POSTGRES_PASSWORD $.Values.postgres.host $EVENTS_DB) }}
 {{- $_ := set $postgres_db_urls "events_analytics_db_url" (printf "postgres://%s:%s@%s:5432/%s" $EVENTS_ANALYTICS_POSTGRES_USER $EVENTS_ANALYTICS_POSTGRES_PASSWORD $.Values.postgres.host $EVENTS_DB) }}
 
 {{/*


### PR DESCRIPTION
- change postgres image to the one with mongo fdw extension
- create new secret `events_superuser_db_url` in `postgres.urls_secret` that's used in the migration service as `EVENTS_SUPERUSER_POSTGRES_URL` env variable
- add `EVENTS_MIGRATION_USER` env variable to migration service