### PR TITLE
fix: run mongo-on-update before migration

### DIFF
--- a/charts/opencrvs-services/templates/mongo-on-update.yaml
+++ b/charts/opencrvs-services/templates/mongo-on-update.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-weight": "1"
   labels:
     app: mongo-on-deploy
   name: mongo-on-deploy


### PR DESCRIPTION
- After updating the dependencies on the kubernetes cluster, I had to run the `mongo-on-deploy` job manually before the `data-migration-job` could run without authentication errors. 
- The `mongo-on-deploy` job had not run yet due to it's `hook-weight` being equal to the `data-migration-job`