### PR TITLE
chore: revert to official postgres

### DIFF
--- a/charts/dependencies/Chart.yaml
+++ b/charts/dependencies/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrvs-dependencies-chart
 description: Dependencies required by OpenCRVS
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: 1.9.0

--- a/charts/dependencies/templates/postgres-backup-cronjob.yaml
+++ b/charts/dependencies/templates/postgres-backup-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: backup
-              image: docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2
+              image: postgres:17
               env:
                 - name: POSTGRES_HOST
                   value: postgres-0.postgres.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/dependencies/templates/postgres-restore-cronjob.yaml
+++ b/charts/dependencies/templates/postgres-restore-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: restore
-              image: docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2
+              image: postgres:17
               env:
                 - name: POSTGRES_HOST
                   value: postgres-0.postgres.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/dependencies/templates/postgres.yaml
+++ b/charts/dependencies/templates/postgres.yaml
@@ -64,7 +64,7 @@ spec:
             {{- end }}
       {{- end }}
       containers: 
-        - image: docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2
+        - image: postgres:17
           name: postgres
           env:
           {{- if .Values.postgres.use_default_credentials }}

--- a/charts/opencrvs-services/templates/data-cleanup-job.yaml
+++ b/charts/opencrvs-services/templates/data-cleanup-job.yaml
@@ -50,7 +50,7 @@ spec:
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "data_cleanup" "Values" .Values) }}
         - name: cleanup-postgres
-          image: docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2
+          image: postgres:17
           command: ["/bin/bash", "-c"]
           args:
             - |

--- a/charts/opencrvs-services/templates/postgres-on-update-analytics-job.yaml
+++ b/charts/opencrvs-services/templates/postgres-on-update-analytics-job.yaml
@@ -18,7 +18,7 @@ spec:
         - name: postgres-on-update-analytics
           command: ["bash", "-c", "/scripts/setup-analytics.sh"]
           # command: ["bash", "-c", "/scripts/on-deploy.sh;"]
-          image: docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2
+          image: postgres:17
           env:
             - name: POSTGRES_HOST
               value: {{ .Values.postgres.host }}

--- a/charts/opencrvs-services/templates/postgres-on-update-core-job.yaml
+++ b/charts/opencrvs-services/templates/postgres-on-update-core-job.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: postgres-on-update-core
           command: ["bash", "-c", "/scripts/on-deploy.sh"]
-          image: docker.io/chumaky/postgres_mongo_fdw:17.6_fdw5.5.2
+          image: postgres:17
           env:
             - name: POSTGRES_HOST
               value: {{ .Values.postgres.host }}


### PR DESCRIPTION
We went with a different approach which doesn't require the e2e repo to use custom postres image. More on this here: https://github.com/opencrvs/opencrvs-core/pull/11048#issuecomment-3627229979