### PR TITLE
fix: Add backward compatibility logic to helm chart

### DIFF
--- a/charts/opencrvs-services/files/setup-analytics.sh
+++ b/charts/opencrvs-services/files/setup-analytics.sh
@@ -12,6 +12,9 @@ set -euo pipefail
 
 TARGET_DB=${TARGET_DB//-/_}
 
+echo "This script will become deprecated in v2.0"
+echo "Check Related Issue: https://github.com/opencrvs/opencrvs-core/issues/11192"
+
 echo "Waiting for PostgreSQL to be ready at ${POSTGRES_HOST}:${POSTGRES_PORT}..."
 until PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
   -U "$POSTGRES_USER" -d postgres -c '\q' 2>/dev/null; do

--- a/charts/opencrvs-services/templates/dashboards-deployment.yaml
+++ b/charts/opencrvs-services/templates/dashboards-deployment.yaml
@@ -54,12 +54,18 @@ spec:
       initContainers:
         - name: copy-assets
           image: "{{ .Values.countryconfig.image.name }}:{{ .Values.countryconfig.image.tag }}-assets"
+          # TODO: [[ -d /assets/metabase ]]: condition was added temporary
+          # to avoid failures until PR will be shipped as part of release to everyone
+          # ETA: OpenCRVS v2.0
+          # Related PR: https://github.com/opencrvs/opencrvs-countryconfig/pull/1184
+          # Related Issue: https://github.com/opencrvs/opencrvs-core/issues/11192
           command:
             - sh
             - -c
             - >
-              cp -R /assets/* /data-assets/ &&
-              chmod +x /data-assets/*.sh || true
+              [[ -d /assets/metabase ]] && cp -R /assets/metabase/* /data-assets/ ||
+              cp -R /assets/* /data-assets/;
+              chmod +x /data-assets/*.sh
           volumeMounts:
             - name: assets
               mountPath: /data-assets

--- a/charts/opencrvs-services/templates/postgres-on-update-analytics-job.yaml
+++ b/charts/opencrvs-services/templates/postgres-on-update-analytics-job.yaml
@@ -1,4 +1,11 @@
 ---
+# TODO: REVIEW: Refactor job move to countryconfig assets
+#       - delete setup-analytics.sh from helm chart
+#       - remove configmap reference: postgres-on-update-script
+#       - Remove related logic
+# ETA: OpenCRVS v2.0
+# Related PR: https://github.com/opencrvs/opencrvs-countryconfig/pull/1184
+# Related Issue: https://github.com/opencrvs/opencrvs-core/issues/11192
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -14,10 +21,25 @@ spec:
       labels:
         app: postgres-on-update-analytics
     spec:
+      initContainers:
+        - name: copy-assets
+          image: "{{ .Values.countryconfig.image.name }}:{{ .Values.countryconfig.image.tag }}-assets"
+          command:
+            - sh
+            - -c
+            - >
+              [[ -d /assets/postgres/ ]] && cp -R /assets/postgres/* /data-assets/ ||
+              cp -LR /scripts/* /data-assets/;
+              chmod +x /data-assets/*.sh || true
+          volumeMounts:
+            - name: assets
+              mountPath: /data-assets
+            # TODO: See comment at the top of this file
+            - mountPath: /scripts
+              name: postgres-on-update-script
       containers:
         - name: postgres-on-update-analytics
-          command: ["bash", "-c", "/scripts/setup-analytics.sh"]
-          # command: ["bash", "-c", "/scripts/on-deploy.sh;"]
+          command: ["bash", "-c", "/data-assets/setup-analytics.sh"]
           image: postgres:17
           env:
             - name: POSTGRES_HOST
@@ -73,11 +95,14 @@ spec:
                   key: EVENTS_ANALYTICS_POSTGRES_PASSWORD
           {{- include "render-env-vars" (dict "service_name" "postgres_on_deploy" "Values" .Values) }}
           volumeMounts:
-            - mountPath: /scripts
-              name: postgres-on-update-script
+            - name: assets
+              mountPath: /data-assets
       volumes:
+        # TODO: See comment at the top of this file
         - name: postgres-on-update-script
           configMap:
             name: postgres-on-update-script
             defaultMode: 0755
+        - name: assets
+          emptyDir: {}
       restartPolicy: "OnFailure"


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/11192

In the future releases we will remove database migration logic from helm repository since it's closer to developers then to devops.

This PR aims to provide helm chart backward compatibility between v1.9.5+ and v2.0 versions.

## Testing

Database migration script was taken from Helm chart:

<img width="1037" height="342" alt="image" src="https://github.com/user-attachments/assets/d7513c31-0ae8-4b14-8993-502664037e60" />
