### PR TITLE
fix: Protect slow starting containers with startup probes

### DIFF
--- a/charts/opencrvs-services/Chart.yaml
+++ b/charts/opencrvs-services/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrvs-services
 description: OpenCRVS Services
 type: application
-version: 0.1.23
-appVersion: 1.9.0
+version: 0.1.24
+appVersion: 1.9.5

--- a/charts/opencrvs-services/README.md
+++ b/charts/opencrvs-services/README.md
@@ -292,6 +292,11 @@ helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
             <td>{}</td>
             <td>Global environment variables, each variable defined here is available to all workloads (service) deployed by helm chart. See example at <a href="values.yaml">values.yaml</a></td>
         </tr>
+        <tr>
+            <td>probes</td>
+            <td>See values.yaml</td>
+            <td>Kubernetes http probes configuration, See defaults at <a href="values.yaml">values.yaml</a>. Each service may have own probes section. Make sure you are familiar with official documentation before changing this sections, see <a href="https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/">Configure Liveness, Readiness and Startup Probes</a>. <b>NOTE: Only httpGet probes are supported.</b></td>
+        </tr>
        <tr>
             <th>Common Service properties</th>
             <th></th>

--- a/charts/opencrvs-services/templates/_helpers.tpl
+++ b/charts/opencrvs-services/templates/_helpers.tpl
@@ -151,3 +151,54 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+
+probes-helper
+---
+This is a helper template that dynamically generates Kubernetes Pod HTTP probes:
+- liveness
+- readiness
+- startup
+
+It accounts for both global and service-specific environment variables and secrets.
+
+Parameters:
+- .ServiceName: The name of the microservice, which is used to access service-specific values.
+- .Values: The top-level Values object for the Helm chart.
+
+*/}}
+{{- define "probes-helper" -}}
+{{- $service_name := .service_name }}
+{{- $service_key_name := ( $service_name | replace "-" "_" ) }}
+{{- $global := .Values.probes }}
+{{- $service_values := index .Values $service_key_name | default dict }}
+{{- $service := $service_values.probes | default dict }}
+livenessProbe:
+  failureThreshold: 5
+  httpGet:
+    path: {{ ( $service.liveness | default dict ).path | default $global.liveness.path }}
+    port: {{ $service_values.port }}
+    scheme: HTTP
+  periodSeconds: {{ ( $service.liveness | default dict ).periodSeconds | default $global.liveness.periodSeconds }}
+  successThreshold: 1
+  timeoutSeconds: {{ ( $service.liveness | default dict ).timeoutSeconds | default $global.liveness.timeoutSeconds }}
+readinessProbe:
+  failureThreshold: 5
+  httpGet:
+    path: {{ ( $service.readiness | default dict ).path | default $global.readiness.path }}
+    port: {{ $service_values.port }}
+    scheme: HTTP
+  periodSeconds: {{ ( $service.readiness | default dict ).periodSeconds | default $global.readiness.periodSeconds }}
+  successThreshold: 1
+  timeoutSeconds: {{ ( $service.readiness | default dict ).timeoutSeconds | default $global.readiness.timeoutSeconds }}
+startupProbe:
+  failureThreshold: 30
+  httpGet:
+    path: {{ ( $service.startup | default dict ).path | default $global.startup.path }}
+    port: {{ $service_values.port }}
+    scheme: HTTP
+  periodSeconds: {{ ( $service.startup | default dict ).periodSeconds | default $global.startup.periodSeconds }}
+  successThreshold: 1
+  timeoutSeconds: {{ ( $service.startup | default dict ).timeoutSeconds | default $global.startup.timeoutSeconds }}
+{{- end }}

--- a/charts/opencrvs-services/templates/auth-deployment.yaml
+++ b/charts/opencrvs-services/templates/auth-deployment.yaml
@@ -95,18 +95,11 @@ spec:
             - name: DOMAIN
               value: {{ .Values.hostname | quote }}
           {{- include "render-env-vars" (dict "service_name" "auth" "Values" .Values) }}
-          {{ include "resources-helper" (dict "service_name" "auth" "Values" .Values) | indent 10 }}
+          {{- include "resources-helper" (dict "service_name" "auth" "Values" .Values) | indent 10 }}
+          {{- include "probes-helper" (dict "service_name" "auth" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.auth.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up x
-              port: {{ .Values.auth.port }}
-          readinessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up
-              port: {{ .Values.auth.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/client-deployment.yaml
+++ b/charts/opencrvs-services/templates/client-deployment.yaml
@@ -66,24 +66,11 @@ spec:
             - name: MINIO_URL
               value: {{ include "render-external-url" (dict "service_name" "minio" "Values" .Values) }}
           {{- include "render-env-vars" (dict "service_name" "client" "Values" .Values) }}
-          {{ include "resources-helper" (dict "service_name" "client" "Values" .Values) | indent 10 }}
+          {{- include "resources-helper" (dict "service_name" "client" "Values" .Values) | indent 10 }}
+          {{- include "probes-helper" (dict "service_name" "client" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.client.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              # /manifest.json is external service proxied by nginx on countryconfig
-              # pod should be restarted once countryconfig is up
-              path: /manifest.json
-              port: {{ .Values.client.port }}
-            periodSeconds: 30
-          readinessProbe:
-            httpGet:
-              # /manifest.json is external service proxied by nginx on countryconfig
-              # pod should be restarted once countryconfig is up
-              path: /manifest.json
-              port: {{ .Values.client.port }}
-            periodSeconds: 30
       restartPolicy: Always
 
 {{- include "service-helper" (dict "service_name" "client" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/config-deployment.yaml
+++ b/charts/opencrvs-services/templates/config-deployment.yaml
@@ -86,20 +86,11 @@ spec:
                   name: {{ .Values.mongodb.urls_secret }}
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "config" "Values" .Values) }}
-          {{ include "resources-helper" (dict "service_name" "config" "Values" .Values) | indent 10 }}
+          {{- include "resources-helper" (dict "service_name" "config" "Values" .Values) | indent 10 }}
+          {{- include "probes-helper" (dict "service_name" "config" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.config.port }}
               protocol: TCP
-          livenessProbe:
-            failureThreshold: 9
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up x
-              port: {{ .Values.config.port }}
-          readinessProbe:
-            failureThreshold: 9
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up
-              port: {{ .Values.config.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/countryconfig-deployment.yaml
+++ b/charts/opencrvs-services/templates/countryconfig-deployment.yaml
@@ -127,18 +127,11 @@ spec:
                   name: {{ .Values.postgres.urls_secret }}
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "countryconfig" "Values" .Values) }}
-          {{ include "resources-helper" (dict "service_name" "countryconfig" "Values" .Values) | indent 10 }}
+          {{- include "resources-helper" (dict "service_name" "countryconfig" "Values" .Values) | indent 10 }}
+          {{- include "probes-helper" (dict "service_name" "countryconfig" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.countryconfig.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up x
-              port: {{ .Values.countryconfig.port }}
-          readinessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up
-              port: {{ .Values.countryconfig.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/documents-deployment.yaml
+++ b/charts/opencrvs-services/templates/documents-deployment.yaml
@@ -53,18 +53,11 @@ spec:
                   name: {{ .Values.minio.users_secret }}
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "documents" "Values" .Values) }}
-          {{ include "resources-helper" (dict "service_name" "documents" "Values" .Values) | indent 10 }}
+          {{- include "resources-helper" (dict "service_name" "documents" "Values" .Values) | indent 10 }}
+          {{- include "probes-helper" (dict "service_name" "documents" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.documents.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up x
-              port: {{ .Values.documents.port }}
-          readinessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up
-              port: {{ .Values.documents.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/events-deployment.yaml
+++ b/charts/opencrvs-services/templates/events-deployment.yaml
@@ -112,15 +112,8 @@ spec:
                   name: {{ .Values.mongodb.urls_secret }}
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "events" "Values" .Values) }}
-          {{ include "resources-helper" (dict "service_name" "events" "Values" .Values) | indent 10 }}
-          livenessProbe:
-            httpGet:
-              path: /health/ready
-              port: {{ .Values.events.port }}
-          readinessProbe:
-            httpGet:
-              path: /health/ready
-              port: {{ .Values.events.port }}
+          {{- include "resources-helper" (dict "service_name" "events" "Values" .Values) | indent 10 }}
+          {{- include "probes-helper" (dict "service_name" "events" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.events.port }}
               protocol: TCP

--- a/charts/opencrvs-services/templates/gateway-deployment.yaml
+++ b/charts/opencrvs-services/templates/gateway-deployment.yaml
@@ -106,22 +106,11 @@ spec:
             - name: COUNTRY_CONFIG_URL
               value: http://countryconfig.{{ .Release.Namespace }}.svc.cluster.local:3040
           {{- include "render-env-vars" (dict "service_name" "gateway" "Values" .Values) }}
-          {{ include "resources-helper" (dict "service_name" "gateway" "Values" .Values) | indent 10 }}
+          {{- include "resources-helper" (dict "service_name" "gateway" "Values" .Values) | indent 10 }}
+          {{- include "probes-helper" (dict "service_name" "gateway" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.gateway.port }}
               protocol: TCP
-          livenessProbe:
-            initialDelaySeconds: 30
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up x
-              port: {{ .Values.gateway.port }}
-            timeoutSeconds: 5
-          readinessProbe:
-            initialDelaySeconds: 30
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up
-              port: {{ .Values.gateway.port }}
-            timeoutSeconds: 5
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/login-deployment.yaml
+++ b/charts/opencrvs-services/templates/login-deployment.yaml
@@ -54,22 +54,11 @@ spec:
             - name: COUNTRY_CONFIG_URL_INTERNAL
               value: http://countryconfig.{{ .Release.Namespace }}.svc.cluster.local:3040
           {{- include "render-env-vars" (dict "service_name" "login" "Values" .Values) }}
-          {{ include "resources-helper" (dict "service_name" "login" "Values" .Values) | indent 10 }}
+          {{- include "resources-helper" (dict "service_name" "login" "Values" .Values) | indent 10 }}
+          {{- include "probes-helper" (dict "service_name" "login" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.login.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              # /api/countryconfig/login-config.js is external service proxied by nginx
-              # pod should be restarted once countryconfig is up
-              path: /api/countryconfig/login-config.js
-              port: {{ .Values.login.port }}
-          readinessProbe:
-            httpGet:
-              # /api/countryconfig/login-config.js is external service proxied by nginx
-              # pod should be restarted once countryconfig is up
-              path: /api/countryconfig/login-config.js
-              port: {{ .Values.login.port }}
       restartPolicy: Always
 
 {{- include "service-helper" (dict "service_name" "login" "Values" .Values) }}

--- a/charts/opencrvs-services/templates/metrics-deployment.yaml
+++ b/charts/opencrvs-services/templates/metrics-deployment.yaml
@@ -70,20 +70,11 @@ spec:
                   name: {{ .Values.mongodb.urls_secret }}
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "metrics" "Values" .Values) }}
-          {{ include "resources-helper" (dict "service_name" "metrics" "Values" .Values) | indent 10 }}
+          {{- include "resources-helper" (dict "service_name" "metrics" "Values" .Values) | indent 10 }}
+          {{- include "probes-helper" (dict "service_name" "metrics" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.metrics.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up x
-              port: {{ .Values.metrics.port }}
-            timeoutSeconds: 3
-          readinessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up
-              port: {{ .Values.metrics.port }}
-            timeoutSeconds: 3
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/notification-deployment.yaml
+++ b/charts/opencrvs-services/templates/notification-deployment.yaml
@@ -46,19 +46,11 @@ spec:
                   name: {{ .Values.mongodb.urls_secret }}
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "notification" "Values" .Values) }}
-          {{ include "resources-helper" (dict "service_name" "notification" "Values" .Values) | indent 10 }}
+          {{- include "resources-helper" (dict "service_name" "notification" "Values" .Values) | indent 10 }}
+          {{- include "probes-helper" (dict "service_name" "notification" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.notification.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up x
-              port: {{ .Values.notification.port }}
-            timeoutSeconds: 3
-          readinessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up
-              port: {{ .Values.notification.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/search-deployment.yaml
+++ b/charts/opencrvs-services/templates/search-deployment.yaml
@@ -54,18 +54,11 @@ spec:
                   name: {{ .Values.mongodb.urls_secret }}
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "search" "Values" .Values) }}
-          {{ include "resources-helper" (dict "service_name" "search" "Values" .Values) | indent 10 }}
+          {{- include "resources-helper" (dict "service_name" "search" "Values" .Values) | indent 10 }}
+          {{- include "probes-helper" (dict "service_name" "search" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.search.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up x
-              port: {{ .Values.search.port }}
-          readinessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up
-              port: {{ .Values.search.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/user-mgnt-deployment.yaml
+++ b/charts/opencrvs-services/templates/user-mgnt-deployment.yaml
@@ -52,18 +52,11 @@ spec:
                   name: {{ .Values.mongodb.urls_secret }}
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "user_mgnt" "Values" .Values) }}
-          {{ include "resources-helper" (dict "service_name" "user_mgnt" "Values" .Values) | indent 10 }}
+          {{- include "resources-helper" (dict "service_name" "user_mgnt" "Values" .Values) | indent 10 }}
+          {{- include "probes-helper" (dict "service_name" "user_mgnt" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.user_mgnt.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up x
-              port: {{ .Values.user_mgnt.port }}
-          readinessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up
-              port: {{ .Values.user_mgnt.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/webhooks-deployment.yaml
+++ b/charts/opencrvs-services/templates/webhooks-deployment.yaml
@@ -93,18 +93,11 @@ spec:
                   name: {{ .Values.redis.users_secret }}
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "webhooks" "Values" .Values) }}
-          {{ include "resources-helper" (dict "service_name" "webhooks" "Values" .Values) | indent 10 }}
+          {{- include "resources-helper" (dict "service_name" "webhooks" "Values" .Values) | indent 10 }}
+          {{- include "probes-helper" (dict "service_name" "webhooks" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.webhooks.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up x
-              port: {{ .Values.webhooks.port }}
-          readinessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up
-              port: {{ .Values.webhooks.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/templates/workflow-deployment.yaml
+++ b/charts/opencrvs-services/templates/workflow-deployment.yaml
@@ -62,18 +62,11 @@ spec:
                   name: {{ .Values.redis.users_secret }}
           {{- end }}
           {{- include "render-env-vars" (dict "service_name" "workflow" "Values" .Values) }}
-          {{ include "resources-helper" (dict "service_name" "workflow" "Values" .Values) | indent 10 }}
+          {{- include "resources-helper" (dict "service_name" "workflow" "Values" .Values) | indent 10 }}
+          {{- include "probes-helper" (dict "service_name" "workflow" "Values" .Values) | indent 10 }}
           ports:
             - containerPort: {{ .Values.workflow.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up x
-              port: {{ .Values.workflow.port }}
-          readinessProbe:
-            httpGet:
-              path: /ping # FIXME: not real healthz, just checking if http server is up
-              port: {{ .Values.workflow.port }}
           volumeMounts:
             - mountPath: /secrets/public-key.pem
               name: public-key

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -181,6 +181,22 @@ ingress:
 # https://kubernetes.io/docs/concepts/services-networking/service/
 service_type: ClusterIP
 
+# Kubernetes HTTP Probes configuration
+probes:
+  liveness:
+    # FIXME: /ping is not real healthz, just checking if http server is up
+    path: /ping
+    periodSeconds: 3
+    timeoutSeconds: 3
+  readiness:
+    path: /ping
+    periodSeconds: 3
+    timeoutSeconds: 3
+  startup:
+    path: /ping
+    periodSeconds: 3
+    timeoutSeconds: 1
+
 # Horizontal Pod Autoscaler (HPA) configuration:
 hpa:
   enabled: true
@@ -237,6 +253,18 @@ auth:
 
 client:
   port: 3000
+  probes:
+    liveness:
+      # /manifest.json is external countryconfig url proxied by nginx on countryconfig
+      # pod should be restarted once countryconfig is up
+      path: /manifest.json
+      periodSeconds: 30
+    readiness:
+      path: /manifest.json
+      periodSeconds: 30
+    startup:
+      path: /manifest.json
+
   env:
     # FIXME: Do we need define this variable?
     DECLARED_DECLARATION_SEARCH_QUERY_COUNT: 100
@@ -280,7 +308,17 @@ gateway:
 
 login:
   port: 3020
-
+  probes:
+    liveness:
+      httpGet:
+        # /api/countryconfig/login-config.js is external service proxied by nginx
+        path: /api/countryconfig/login-config.js
+    readiness:
+      httpGet:
+        path: /api/countryconfig/login-config.js
+    startup:
+      httpGet:
+        path: /api/countryconfig/login-config.js
 
 metrics:
   port: 1050
@@ -311,7 +349,15 @@ workflow:
 
 events:
   port: 5555
-
+  probes:
+    liveness:
+      path: /health/ready
+      timeoutSeconds: 10
+    readiness:
+      path: /health/ready
+      timeoutSeconds: 10
+    startup:
+      path: /health/ready
 
 scheduler: {}
 


### PR DESCRIPTION
## Description

Goal of this PR is to give DevOps / System Administrator a way to adjust service startup and runtime behaviour.

Recently 2 kinds of issues were observed:
- Slow pod startup (config service), see internal link: https://opencrvsworkspace.slack.com/archives/C02LU432JGK/p1764844970722819
- Random pod restart (events service) on liveness probe failure. Output from `kubectl describe` command:
   ```
     Warning  Unhealthy  4m10s (x16 over 14m)  kubelet            Readiness probe failed: Get       "http://192.168.184.167:5555/health/ready": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
   ```

Example of failure `events` service:
```
...
Containers:
  events:
    Container ID:   containerd://6ff80deacb421e4be9bd1ce093f46621ccc6146e3eb1923c2d180603bd2b7478
    Image:          ghcr.io/opencrvs/ocrvs-events:5ccf91d
    Image ID:       ghcr.io/opencrvs/ocrvs-events@sha256:340944022960e381d836fa48b59c7d160c8f1342e32bec3b27de65252f95b9c0
    Port:           5555/TCP
    Host Port:      0/TCP
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       Error
      Exit Code:    1
      Started:      Mon, 05 Jan 2026 16:02:48 +0200
      Finished:     Mon, 05 Jan 2026 16:03:28 +0200
...
  Warning  Unhealthy  8m23s (x40 over 38m)  kubelet            Liveness probe failed: Get "http://192.168.184.143:5555/health/ready": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
  Warning  Unhealthy  3m21s (x57 over 38m)  kubelet            Readiness probe failed: Get "http://192.168.184.143:5555/health/ready": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
...
```

## How it works?
- For config: startup probe will avoid container restart until it starts:
   - previous: 3 sequential health-check failures at startup time lead to container restart
   - new behaviour: container will wait up to `failureThreshold*periodSeconds` (30*3 = 90 seconds) for health-check success
- For events: due to high CPU usage liveness probe became slow at some point. Probe was decelerated at service level `events.probes` to increase timeoutSeconds

## Testing


Helm install/upgrade:

https://github.com/user-attachments/assets/380c5d7c-c2c7-49e8-9f0c-1f2a2bbab6cf

Verify options applied successfully:

events service was deployed with values supplied by `values.yaml`:
```
    Liveness:   http-get http://:5555/health/ready delay=0s timeout=10s period=3s #success=1 #failure=5
    Readiness:  http-get http://:5555/health/ready delay=0s timeout=10s period=3s #success=1 #failure=5
    Startup:    http-get http://:5555/health/ready delay=0s timeout=1s period=3s #success=1 #failure=30
```

values.yaml:
```yaml
events:
  port: 5555
  probes:
    liveness:
      path: /health/ready
      timeoutSeconds: 10
    readiness:
      path: /health/ready
      timeoutSeconds: 10
    startup:
      path: /health/ready
```

https://github.com/user-attachments/assets/8ddb95d5-48f5-445a-ab32-e606ac901fa0


