### PR TITLE
feat: Customise nginx conf.d

### DIFF
--- a/charts/opencrvs-services/Chart.yaml
+++ b/charts/opencrvs-services/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrvs-services
 description: OpenCRVS Services
 type: application
-version: 0.1.25
+version: 0.1.26
 appVersion: 1.9.5

--- a/charts/opencrvs-services/README.md
+++ b/charts/opencrvs-services/README.md
@@ -373,6 +373,16 @@ helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
             <th>Properties listed below can be defined particularly to specific service</th>
         </tr>
         <tr>
+            <td>login.nginx_conf_d_configmaps</td>
+            <td>{}</td>
+            <td>List of Configmap names to store custom configuration. Check <code>values.yaml</code> for more details.</td>
+        </tr>
+        <tr>
+            <td>client.nginx_conf_d_configmaps</td>
+            <td>{}</td>
+            <td> login is an nginx docker image. see description for <code>login.nginx_conf_d_configmaps</code></td>
+        </tr>
+        <tr>
             <td>data_seed.enabled</td>
             <td>true</td>
             <td>Seed data as post-install step which is executed only once while `helm install`. **Note**: default username and password is used for data seeding. **If you need to seed data again, use one-time jobs instead.</td>

--- a/charts/opencrvs-services/templates/client-deployment.yaml
+++ b/charts/opencrvs-services/templates/client-deployment.yaml
@@ -71,7 +71,23 @@ spec:
           ports:
             - containerPort: {{ .Values.client.port }}
               protocol: TCP
+          {{- if .Values.client.nginx_conf_d_configmaps }}
+          volumeMounts:
+          {{- range $config_name := .Values.client.nginx_conf_d_configmaps }}
+            - name: {{ $config_name }}
+              mountPath: /etc/nginx/conf.d/{{ $config_name }}.conf
+              subPath: "{{ $config_name }}.conf"
+          {{- end }}
+          {{- end }}
       restartPolicy: Always
+      {{- if .Values.client.nginx_conf_d_configmaps }}
+      volumes:
+      {{- range $config_name := .Values.client.nginx_conf_d_configmaps }}
+        - name: {{ $config_name }}
+          configMap:
+            name: {{ $config_name }}
+      {{- end }}
+      {{- end }}
 
 {{- include "service-helper" (dict "service_name" "client" "Values" .Values) }}
 

--- a/charts/opencrvs-services/templates/login-deployment.yaml
+++ b/charts/opencrvs-services/templates/login-deployment.yaml
@@ -59,7 +59,23 @@ spec:
           ports:
             - containerPort: {{ .Values.login.port }}
               protocol: TCP
+          {{- if .Values.client.nginx_conf_d_configmaps }}
+          volumeMounts:
+          {{- range $config_name := .Values.login.nginx_conf_d_configmaps }}
+            - name: {{ $config_name }}
+              mountPath: /etc/nginx/conf.d/{{ $config_name }}.conf
+              subPath: "{{ $config_name }}.conf"
+          {{- end }}
+          {{- end }}
       restartPolicy: Always
+      {{- if .Values.login.nginx_conf_d_configmaps }}
+      volumes:
+      {{- range $config_name := .Values.login.nginx_conf_d_configmaps }}
+        - name: {{ $config_name }}
+          configMap:
+            name: {{ $config_name }}
+      {{- end }}
+      {{- end }}
 
 {{- include "service-helper" (dict "service_name" "login" "Values" .Values) }}
 

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -253,6 +253,8 @@ auth:
 
 client:
   port: 3000
+  # client is an nginx docker image
+  # nginx_conf_d_configmaps: see description for login.nginx_conf_d_configmaps section
   probes:
     liveness:
       # /manifest.json is external countryconfig url proxied by nginx on countryconfig
@@ -308,6 +310,25 @@ gateway:
 
 login:
   port: 3020
+  # login is an nginx docker image
+  # nginx_conf_d_configmaps: 
+  #     List of Configmap names to store custom configuration:
+  #     - each configmap must contain one configuration file
+  #     - configuration file name must match with configmap name
+  #     - each configmap is mounted inside /etc/nginx/conf.d.
+  # Example:
+  # nginx_conf_d_configmaps:
+  #   - login-nginx-headers
+  #   - login-nginx-auth
+  # Mounted files:
+  # ls -1 /etc/nginx/conf.d
+  # login-nginx-headers.conf
+  # login-nginx-auth.conf
+  # default.conf <- this file exists by default
+  # Example command to create configmap:
+  # kubectl create configmap login-nginx-login --from-file=foo.conf --from-file=login-nginx-login.conf
+  # login-nginx-login: is configmap name
+  # login-nginx-login.conf is file name. it should be same as configmap with .conf ending
   probes:
     liveness:
       httpGet:


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/11538

This PR aims to implement option to supply custom configuration files for nginx

## Testing

Values snippet:

```yaml
client:
  nginx_conf_d_configmaps:
    - test
```

Configmap:
<img width="487" height="199" alt="image" src="https://github.com/user-attachments/assets/eace8649-6a98-4c1f-8f40-5942e56b4315" />


Screenshot after deployment:

test.conf from configmap test is mounted on filesystem at /etc/nginx/conf.d/test.conf
<img width="1125" height="596" alt="image" src="https://github.com/user-attachments/assets/c29cbb32-14fd-49b7-8c65-fd801e5c25db" />

Check file content:
<img width="657" height="85" alt="image" src="https://github.com/user-attachments/assets/a0051293-8162-4e09-81b7-83526d1d3d2c" />
