### PR TITLE
WIP: feat: Make sub-domain separator configurable

### DIFF
--- a/charts/opencrvs-services/README.md
+++ b/charts/opencrvs-services/README.md
@@ -268,6 +268,11 @@ helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
             <td>Hostname for OpenCRVS application, without wildcard or subdomain. Example: hostname: opencrvs.localhost</td>
         </tr>
         <tr>
+            <td>subdomain_separator</td>
+            <td><code>.</code></td>
+            <td>Separator between <code>hostname</code> and subdomains. See values.yaml for more information.</td>
+        </tr>
+        <tr>
             <td>ingress.ssl_enabled</td>
             <td>true</td>
             <td>Enable or disable https endpoint, by default all http traffic is routed to https</td>

--- a/charts/opencrvs-services/templates/_helpers.tpl
+++ b/charts/opencrvs-services/templates/_helpers.tpl
@@ -47,10 +47,16 @@ Parameters:
 {{- end }}
 {{- end }}
 
+{{- define "render-external-subdomain" -}}
+{{- $service_name := .service_name }}
+{{- $http_scheme := include "http-scheme" . }}
+{{- printf "%s%s%s" $service_name ( .Values.subdomain_separator | default ".") .Values.hostname }}
+{{- end }}
+
 {{- define "render-external-url" -}}
 {{- $service_name := .service_name }}
 {{- $http_scheme := include "http-scheme" . }}
-{{- printf "%s://%s.%s" $http_scheme $service_name .Values.hostname }}
+{{- printf "%s://%s%s%s" $http_scheme $service_name ( .Values.subdomain_separator | default ".") .Values.hostname }}
 {{- end }}
 
 {{- define "service-helper" -}}

--- a/charts/opencrvs-services/templates/auth-deployment.yaml
+++ b/charts/opencrvs-services/templates/auth-deployment.yaml
@@ -12,7 +12,7 @@ spec:
     - web
   {{- end }}
   routes:
-  - match: 'Host(`auth.{{ .Values.hostname }}`)'
+  - match: 'Host(`{{ include "render-external-subdomain" (dict "service_name" "auth" "Values" .Values) }}`)'
     kind: Rule
     services:
     - name: auth

--- a/charts/opencrvs-services/templates/client-deployment.yaml
+++ b/charts/opencrvs-services/templates/client-deployment.yaml
@@ -12,7 +12,7 @@ spec:
     - web
   {{- end }}
   routes:
-  - match: 'Host(`register.{{ .Values.hostname }}`) || Host(`{{ .Values.hostname }}`)'
+  - match: 'Host(`{{ include "render-external-subdomain" (dict "service_name" "register" "Values" .Values) }}`) || Host(`{{ .Values.hostname }}`)'
     kind: Rule
     services:
     - name: client

--- a/charts/opencrvs-services/templates/config-deployment.yaml
+++ b/charts/opencrvs-services/templates/config-deployment.yaml
@@ -12,7 +12,7 @@ spec:
     - web
   {{- end }}
   routes:
-  - match: 'Host(`config.{{ .Values.hostname }}`)'
+  - match: 'Host(`{{ include "render-external-subdomain" (dict "service_name" "config" "Values" .Values) }}`)'
     kind: Rule
     services:
     - name: config

--- a/charts/opencrvs-services/templates/countryconfig-deployment.yaml
+++ b/charts/opencrvs-services/templates/countryconfig-deployment.yaml
@@ -12,7 +12,7 @@ spec:
     - web
   {{- end }}
   routes:
-  - match: 'Host(`countryconfig.{{ .Values.hostname }}`) && !Path(`/email`) && !Path(`/notification`) && !Path(`/dashboards/queries.json`)'
+  - match: 'Host(`{{ include "render-external-subdomain" (dict "service_name" "countryconfig" "Values" .Values) }}`) && !Path(`/email`) && !Path(`/notification`) && !Path(`/dashboards/queries.json`)'
     kind: Rule
     services:
     - name: countryconfig
@@ -21,7 +21,7 @@ spec:
     middlewares:
       - name: sts-and-basic-response-headers
       - name: enable-compression
-  - match: 'Host(`countryconfig.{{ .Values.hostname }}`) && Path(`/email`)'
+  - match: 'Host(`{{ include "render-external-subdomain" (dict "service_name" "countryconfig" "Values" .Values) }}`) && Path(`/email`)'
     kind: Rule
     services:
     - name: countryconfig
@@ -29,7 +29,7 @@ spec:
       port: {{ .Values.countryconfig.port }}
     middlewares:
       - name: block-internal-routes
-  - match: 'Host(`countryconfig.{{ .Values.hostname }}`) && Path(`/notification`)'
+  - match: 'Host(`{{ include "render-external-subdomain" (dict "service_name" "countryconfig" "Values" .Values) }}`) && Path(`/notification`)'
     kind: Rule
     services:
     - name: countryconfig
@@ -37,7 +37,7 @@ spec:
       port: {{ .Values.countryconfig.port }}
     middlewares:
       - name: block-internal-routes
-  - match: 'Host(`countryconfig.{{ .Values.hostname }}`) && Path(`/dashboards/queries.json`)'
+  - match: 'Host(`{{ include "render-external-subdomain" (dict "service_name" "countryconfig" "Values" .Values) }}`) && Path(`/dashboards/queries.json`)'
     kind: Rule
     services:
     - name: countryconfig

--- a/charts/opencrvs-services/templates/dashboards-deployment.yaml
+++ b/charts/opencrvs-services/templates/dashboards-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     - web
   {{- end }}
   routes:
-  - match: 'Host(`metabase.{{ .Values.hostname }}`)'
+  - match: 'Host(`{{ include "render-external-subdomain" (dict "service_name" "metabase" "Values" .Values) }}`)'
     kind: Rule
     services:
     - name: dashboards

--- a/charts/opencrvs-services/templates/events-deployment.yaml
+++ b/charts/opencrvs-services/templates/events-deployment.yaml
@@ -12,7 +12,7 @@ spec:
     - web
   {{- end }}
   routes:
-  - match: 'Host(`events.{{ .Values.hostname }}`)'
+  - match: 'Host(`{{ include "render-external-subdomain" (dict "service_name" "events" "Values" .Values) }}`)'
     kind: Rule
     services:
     - name: events

--- a/charts/opencrvs-services/templates/gateway-deployment.yaml
+++ b/charts/opencrvs-services/templates/gateway-deployment.yaml
@@ -12,7 +12,7 @@ spec:
     - web
   {{- end }}
   routes:
-  - match: 'Host(`gateway.{{ .Values.hostname }}`)'
+  - match: 'Host(`{{ include "render-external-subdomain" (dict "service_name" "gateway" "Values" .Values) }}`)'
     kind: Rule
     services:
     - name: gateway

--- a/charts/opencrvs-services/templates/login-deployment.yaml
+++ b/charts/opencrvs-services/templates/login-deployment.yaml
@@ -12,7 +12,7 @@ spec:
     - web
   {{- end }}
   routes:
-  - match: 'Host(`login.{{ .Values.hostname }}`) || Host(`{{ .Values.hostname }}`)'
+  - match: 'Host(`{{ include "render-external-subdomain" (dict "service_name" "login" "Values" .Values) }}`) || Host(`{{ .Values.hostname }}`)'
     kind: Rule
     services:
     - name: login

--- a/charts/opencrvs-services/templates/webhooks-deployment.yaml
+++ b/charts/opencrvs-services/templates/webhooks-deployment.yaml
@@ -12,7 +12,7 @@ spec:
     - web
   {{- end }}
   routes:
-  - match: 'Host(`webhooks.{{ .Values.hostname }}`)'
+  - match: 'Host(`{{ include "render-external-subdomain" (dict "service_name" "webhooks" "Values" .Values) }}`)'
     kind: Rule
     services:
     - name: webhooks

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -169,6 +169,17 @@ postgres:
 # All OpenCRVS services will be available under domain:
 hostname: opencrvs.localhost
 
+# subdomain_separator: separator between hostname and subdomains
+# generic form: <subdomain><subdomain_separator><hostname>
+# OpenCRVS can be deployed in different ways:
+# - as set of subdomains to hostname, examples:
+#            - auth.opencrvs.localhost
+#            - register.opencrvs.localhost
+# - as set of variations to main domain, 
+#   in this variant wildcard certificate is needed only to one domain, examples:
+#            - auth-opencrvs.localhost
+#            - register-opencrvs.localhost
+subdomain_separator: "."
 
 ingress:
   # Access OpenCRVS services at https://<hostname>/


### PR DESCRIPTION
Goal of this PR is to make subdomain separator configurable. OpenCRVS can be deployed in different ways:
- as set of subdomains to hostname, examples:
   - auth.opencrvs.localhost
   - register.opencrvs.localhost
- as set of variations to main domain, in this variant wildcard certificate is needed only to one domain, examples:
   - auth-opencrvs.localhost
   - register-opencrvs.localhost
