### PR TITLE
fix: Allow timezone definition for Kubernetes cronjobs

### DIFF
--- a/charts/dependencies/README.md
+++ b/charts/dependencies/README.md
@@ -35,6 +35,7 @@ Any particular service within this helm chart can be disabled by setting `<servi
 | ingress.ssl_enabled      | bool    | false   | Enable or disable https endpoint, by default all http traffic is routed to https |
 | ingress.tls_resolver | string | ` ` | If traefik was deployed with custom resolver, please define resolver name here. Resolver will be attached to Traefik CRD IngressRoute, otherwise default Traefik SSL Certificate will be used. |
 | ingress.tls_secret_name | string | ` ` | Secret with custom SSL Certificate for IngressRoute, check traefik documentation for details. Otherwise default Traefik SSL Certificate will be used.  |
+| timezone     | string | ` ` | Time zone for a backup and restore CronJobs, by default local time zone is used from server |
 | storage_type | string | `pvc` | Kubernetes storage type, available options are `pvc` or `host_path`. More information are at [Storage Configuration](#storage-configuration) |
 | node_selector | dict | `{}` | Label selector for datastore nodes, usually used to keep data persistent |
 | monitoring.enabled | bool | `false` | Enable or disable monitoring, see [Monitoring](#monitoring) |

--- a/charts/dependencies/templates/influxdb-backup-cronjob.yaml
+++ b/charts/dependencies/templates/influxdb-backup-cronjob.yaml
@@ -14,6 +14,9 @@ metadata:
 spec:
   {{ if .Values.backup.cronjob }}
   schedule: {{ .Values.influxdb.backup_schedule | default .Values.backup.schedule }}
+  {{- if .Values.timezone }}
+  timeZone: {{ .Values.timezone }}
+  {{- end }}
   jobTemplate:
     spec:
   {{- end }}

--- a/charts/dependencies/templates/influxdb-restore-cronjob.yaml
+++ b/charts/dependencies/templates/influxdb-restore-cronjob.yaml
@@ -14,6 +14,9 @@ metadata:
 spec:
   {{ if .Values.restore.cronjob }}
   schedule: {{ .Values.influxdb.restore_schedule | default .Values.restore.schedule }}
+  {{- if .Values.timezone }}
+  timeZone: {{ .Values.timezone }}
+  {{- end }}
   jobTemplate:
     spec:
   {{- end }}

--- a/charts/dependencies/templates/minio-backup-cronjob.yaml
+++ b/charts/dependencies/templates/minio-backup-cronjob.yaml
@@ -14,6 +14,9 @@ metadata:
 spec:
   {{ if .Values.backup.cronjob }}
   schedule: {{ .Values.minio.backup_schedule | default .Values.backup.schedule }}
+  {{- if .Values.timezone }}
+  timeZone: {{ .Values.timezone }}
+  {{- end }}
   jobTemplate:
     spec:
   {{- end }}

--- a/charts/dependencies/templates/minio-restore-cronjob.yaml
+++ b/charts/dependencies/templates/minio-restore-cronjob.yaml
@@ -14,6 +14,9 @@ metadata:
 spec:
   {{ if .Values.restore.cronjob }}
   schedule: {{ .Values.minio.restore_schedule | default .Values.restore.schedule }}
+  {{- if .Values.timezone }}
+  timeZone: {{ .Values.timezone }}
+  {{- end }}
   jobTemplate:
     spec:
   {{- end }}

--- a/charts/dependencies/templates/mongodb-backup-cronjob.yaml
+++ b/charts/dependencies/templates/mongodb-backup-cronjob.yaml
@@ -14,6 +14,9 @@ metadata:
 spec:
   {{ if .Values.backup.cronjob }}
   schedule: {{ .Values.mongodb.backup_schedule | default .Values.backup.schedule }}
+  {{- if .Values.timezone }}
+  timeZone: {{ .Values.timezone }}
+  {{- end }}
   jobTemplate:
     spec:
   {{- end }}

--- a/charts/dependencies/templates/mongodb-restore-cronjob.yaml
+++ b/charts/dependencies/templates/mongodb-restore-cronjob.yaml
@@ -14,6 +14,9 @@ metadata:
 spec:
   {{ if .Values.restore.cronjob }}
   schedule: {{ .Values.restore.backup_schedule | default .Values.restore.schedule }}
+  {{- if .Values.timezone }}
+  timeZone: {{ .Values.timezone }}
+  {{- end }}
   jobTemplate:
     spec:
   {{- end }}

--- a/charts/dependencies/templates/postgres-backup-cronjob.yaml
+++ b/charts/dependencies/templates/postgres-backup-cronjob.yaml
@@ -14,6 +14,9 @@ metadata:
 spec:
   {{ if .Values.backup.cronjob }}
   schedule: {{ .Values.postgres.backup_schedule | default .Values.backup.schedule }}
+  {{- if .Values.timezone }}
+  timeZone: {{ .Values.timezone }}
+  {{- end }}
   jobTemplate:
     spec:
   {{- end }}

--- a/charts/dependencies/templates/postgres-restore-cronjob.yaml
+++ b/charts/dependencies/templates/postgres-restore-cronjob.yaml
@@ -14,6 +14,9 @@ metadata:
 spec:
   {{ if .Values.restore.cronjob }}
   schedule: {{ .Values.postgres.restore_schedule | default .Values.restore.schedule }}
+  {{- if .Values.timezone }}
+  timeZone: {{ .Values.timezone }}
+  {{- end }}
   jobTemplate:
     spec:
   {{- end }}

--- a/charts/dependencies/values.yaml
+++ b/charts/dependencies/values.yaml
@@ -12,6 +12,14 @@ ingress:
 # Kubernetes storage type, available options are `pvc` or `host_path`
 storage_type: pvc
 
+
+# timezone: You can specify a time zone for a CronJobs (backup/restore)
+# https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+# For CronJobs with no time zone specified, the kube-controller-manager interprets schedules relative to its local time zone.
+# Example:
+# timezone: "Etc/UTC"
+
+
 # FIXME: Tiltfile deploys helm chart as template. There is no way to track existing secrets on the cluster.
 # This flag was introduced to avoid secrets update (mutation) on every file change within chart directory.
 # For OpenCRVS developers there is no need to deploy dependencies helm chart as template.

--- a/charts/opencrvs-services/README.md
+++ b/charts/opencrvs-services/README.md
@@ -293,6 +293,11 @@ helm upgrade --install opencrvs oci://ghcr.io/opencrvs/opencrvs-services \
             <td>Global environment variables, each variable defined here is available to all workloads (service) deployed by helm chart. See example at <a href="values.yaml">values.yaml</a></td>
         </tr>
         <tr>
+            <td>timezone</td>
+            <td></td>
+            <td>Time zone for a backup and restore CronJobs, by default local time zone is used from server. See example at <a href="values.yaml">values.yaml</a></td>
+        </tr>
+        <tr>
             <td>probes</td>
             <td>See values.yaml</td>
             <td>Kubernetes http probes configuration, See defaults at <a href="values.yaml">values.yaml</a>. Each service may have own probes section. Make sure you are familiar with official documentation before changing this sections, see <a href="https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/">Configure Liveness, Readiness and Startup Probes</a>. <b>NOTE: Only httpGet probes are supported.</b></td>

--- a/charts/opencrvs-services/templates/elasticsearch-reindex-job.yaml
+++ b/charts/opencrvs-services/templates/elasticsearch-reindex-job.yaml
@@ -25,6 +25,9 @@ metadata:
   name: elasticsearch-reindex
 spec:
   schedule: "{{ .Values.elasticsearch.cronjob.schedule }}"
+{{- if .Values.timezone }}
+  timeZone: {{ .Values.timezone }}
+{{- end }}
   jobTemplate:
     spec:
 {{ include "elasticsearch-reindex.podSpec" . | indent 6 }}

--- a/charts/opencrvs-services/values.yaml
+++ b/charts/opencrvs-services/values.yaml
@@ -181,6 +181,13 @@ ingress:
 # https://kubernetes.io/docs/concepts/services-networking/service/
 service_type: ClusterIP
 
+
+# timezone: You can specify a time zone for a CronJobs
+# https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+# For CronJobs with no time zone specified, the kube-controller-manager interprets schedules relative to its local time zone.
+# Example:
+# timezone: "Etc/UTC"
+
 # Kubernetes HTTP Probes configuration
 probes:
   liveness:


### PR DESCRIPTION
This PR aims to add Timezone support to Kubernetes cronjobs:
https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones