### PR TITLE
feat: Added minio backup/restore in mirror mode

### DIFF
--- a/charts/dependencies/README.md
+++ b/charts/dependencies/README.md
@@ -103,11 +103,11 @@ This section allows you to configure the deployment and authentication settings 
 | storage_type    | string | `pvc` |  Kubernetes storage type, available options are `pvc` or `host_path`. More information are at [Storage Configuration](#storage-configuration) |
 | host_data_path  | string | `/data/elasticsearch` | Path to persistent data on VM (host) |
 | node_selector   | dict | `{}` | Label selector for datastore nodes, usually used to keep data persistent |
-| backup_schedule | string | `n/a` | Backup cronjob schedule, if not defined then values from `backup.schedule` is used |
-| backup_server_dir | string | `n/a` | Directory to store encrypted backup on backup server, if not defined `backup.backup_server_dir` is used |
+
 
 ## MinIO
 
+### Configuration options
 | Key | Default value | Description |
 |-|-|-|
 | enabled | true | Enable or disable minio service |
@@ -116,9 +116,19 @@ This section allows you to configure the deployment and authentication settings 
 | storage_type    | string | `pvc` |  Kubernetes storage type, available options are `pvc` or `host_path`. More information are at [Storage Configuration](#storage-configuration) |
 | host_data_path  | string | `/data/minio` | Path to persistent data on VM (host) |
 | node_selector   | dict | `{}` | Label selector for datastore nodes, usually used to keep data persistent |
-| backup_schedule | string | `n/a` | Backup cronjob schedule, if not defined then values from `backup.schedule` is used |
-| backup_server_dir | string | `n/a` | Directory to store encrypted backup on backup server, if not defined `backup.backup_server_dir` is used |
+| backup.{}       | dict | `{}` | Backup configuration section, for more information please check `values.yaml` and **Backup section** in this README |
+| backup.enabled  | string | `false` | Backup enabled or disabled, section has higher priority over global `backup` section |
+| backup.type     | string | `dump` | `dump` is a full filesystem dump, `mirror` is a filesystem mirror on remote backup server |
+| backup.server_secret | string | `backup-server-ssh-credentials` | Name of the Kubernetes secret with backup server credentials       |
+| backup.schedule | string | `0 1 * * *` | Time to run backup job, if not defined then value from `backup.schedule` is used |
+| backup.server_dir | string | `n/a` | Directory on backup server for encrypted backups or filesystem mirror. Uses global value if not set |
+| restore.{}       | dict | `{}` | Restore configuration section, for more information please check `values.yaml` and **Restore section** in this README |
+| restore.enabled  | string | `false` | Enables restore functionality; section overrides global `restore` settings. |
+| restore.type     | string | `dump` | Restore method: `dump` (from encrypted archive) or `mirror` (mirror from remote backup server) |
+| restore.server_secret | string | `backup-server-ssh-credentials` | Name of the Kubernetes secret with backup server credentials, usually backup server is used for restore, thats why credentials are shared |
+| restore.schedule | string | `0 3 * * *` | Restore cronjob schedule, if not defined then value from `restore.schedule` is used |
 
+### MinIO Credentials
 Setting `use_default_credentials` to `false` will generate strong password for MinIO.
 
 MinIO defaults to minioadmin and minioadmin as the access key and secret key respectively.
@@ -155,6 +165,10 @@ documents:
       - MINIO_SECRET_KEY
 ```
 
+### Backup and Restore Section Reference
+
+For detailed configuration, review the values.yaml file and refer to the Backup and Restore sections of this README.
+Adjust schedules, server credentials, and directories as needed for your deployment.
 
 ## Redis
 

--- a/charts/dependencies/files/minio/backup.sh
+++ b/charts/dependencies/files/minio/backup.sh
@@ -24,7 +24,6 @@ REMOTE_DIR="${BACKUP_REMOTE_DIR:-"/home/$BACKUP_USER"}/$BACKUP_DATE"
 # Number of retries for backup creation
 MAX_RETRIES=10
 
-BACKUP_MODE=${BACKUP_MODE:-"fs"}
 # Install required tools
 apk add --no-cache bash curl openssl openssh jq rsync minio-client
 
@@ -33,9 +32,9 @@ if [ -z "$ENCRYPT_PASS" ]; then
   echo "[$(date +%F\ %H:%M:%S)] [ERROR] Must provide ENCRYPT_PASS environment variable"
   exit 1
 fi
+
 # Mirror data before backup
-# Works well on any minio installation but is slower and requires additional disk space
-backup_mirror(){
+backup_and_archive(){
   MINIO_ALIAS=local
   mcli alias set $MINIO_ALIAS http://minio:3535 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD
 
@@ -53,13 +52,6 @@ backup_mirror(){
 
   echo "Backup completed! Buckets saved at: $BACKUP_PATH"
   cd $BACKUP_PATH && tar -zcvf $ARCHIVE_PATH .
-}
-
-# Backup entire filesystem
-# Works well on single node installation and is fastest way to create backup
-backup_fs(){
-  echo "[$(date +%F\ %H:%M:%S)] Archive backup at $ARCHIVE_PATH"
-  cd /data && tar -zcvf $ARCHIVE_PATH .
 }
 
 create_encrypted_backup(){
@@ -88,11 +80,8 @@ echo "[$(date +%F\ %H:%M:%S)] Running backup container"
 echo "[$(date +%F\ %H:%M:%S)] Setup connection to container http://minio:3535"
 
 
-if [ $BACKUP_MODE == "fs" ]; then
-  backup_fs
-elif [ $BACKUP_MODE == "mirror" ]; then
-  backup_mirror
-fi
+backup_and_archive
+
 create_encrypted_backup
 
 transfer_to_backup_host

--- a/charts/dependencies/templates/_minio-backup-helper.tpl
+++ b/charts/dependencies/templates/_minio-backup-helper.tpl
@@ -1,0 +1,47 @@
+{{/*
+minio.backup_enabled
+---
+CAUTION: This helper returns string value (not boolean)
+
+Check backup is enabled or not
+*/}}
+{{- define "minio.backup_enabled" -}}
+{{- if or 
+    .Values.backup.enabled
+    .Values.minio.backup.enabled 
+}}true{{- else }}false{{- end }}
+{{- end }}
+
+{{/*
+minio.restore_enabled
+---
+CAUTION: This helper returns string value (not boolean)
+
+Check restore is enabled or not
+*/}}
+{{- define "minio.restore_enabled" -}}
+{{- if or 
+    .Values.restore.enabled
+    .Values.minio.restore.enabled 
+}}true{{- else }}false{{- end }}
+{{- end }}
+
+{{/*
+minio.use_mirror
+---
+CAUTION: This helper returns string value (not boolean)
+
+Render differential backup properties
+*/}}
+{{- define "minio.use_mirror" -}}
+  {{- if and
+      (or
+        (eq .Values.minio.backup.type "mirror")
+        (eq .Values.minio.restore.type "mirror")
+      )
+      (or
+        (eq (include "minio.backup_enabled" .) "true")
+        (eq (include "minio.restore_enabled" .) "true")
+      )
+  }}true{{- else }}false{{- end }}
+{{- end }}

--- a/charts/dependencies/templates/backup-runner-sa.yaml
+++ b/charts/dependencies/templates/backup-runner-sa.yaml
@@ -1,17 +1,17 @@
 {{/*
-Service account postgres-backup-runner is shared between backup and restore CronJobs
+Service account backup-runner is shared between backup and restore CronJobs
 */}}
 {{- if (eq (include "postgres.use_pgBackRest" .) "true") }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: postgres-backup-runner
+  name: backup-runner
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: postgres-backup-runner-role
+  name: backup-runner-role
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -31,13 +31,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: postgres-backup-runner-binding
+  name: backup-runner-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: postgres-backup-runner-role
+  name: backup-runner-role
 subjects:
   - kind: ServiceAccount
-    name: postgres-backup-runner
+    name: backup-runner
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/dependencies/templates/minio-backup-cronjob.yaml
+++ b/charts/dependencies/templates/minio-backup-cronjob.yaml
@@ -1,4 +1,5 @@
-{{ if and .Values.minio.enabled .Values.backup.enabled }}
+{{ if and .Values.minio.enabled (eq (include "minio.backup_enabled" .) "true") }}
+{{- if eq .Values.minio.backup.type "dump" }}
 ---
 apiVersion: batch/v1
 {{ if .Values.backup.cronjob }}
@@ -32,8 +33,6 @@ spec:
               command: ["/scripts/backup.sh"]
               image: "bash"
               env:
-                - name: BACKUP_MODE
-                  value: "mirror"
               {{- if not .Values.minio.use_default_credentials }}
                 - name: MINIO_ROOT_USER
                   valueFrom:
@@ -82,4 +81,38 @@ spec:
               configMap:
                 name: minio-scripts
                 defaultMode: 0755
+{{- end }}
+{{- if eq .Values.minio.backup.type "mirror" }}
+---
+apiVersion: batch/v1
+{{ if .Values.backup.cronjob }}
+kind: CronJob
+{{- else }}
+kind: Job
+{{- end }}
+metadata:
+  name: minio-backup
+spec:
+  {{ if .Values.backup.cronjob }}
+  schedule: {{ default .Values.backup.schedule .Values.minio.backup.schedule }}
+  {{- if .Values.timezone }}
+  timeZone: {{ .Values.timezone }}
+  {{- end }}
+  jobTemplate:
+    spec:
+  {{- end }}
+      template:
+        spec:
+          serviceAccountName: backup-runner
+          containers:
+            - name: runner
+              image: bitnami/kubectl:latest
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  kubectl exec minio-0 -c rsync -- \
+                    /bin/sh -c "rsync -avz --exclude='.minio.sys/config/iam/' -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' /data/ \$BACKUP_USER@\$BACKUP_HOST:\$BACKUP_REMOTE_DIR/minio"
+          restartPolicy: OnFailure
+{{- end }}
 {{- end }}

--- a/charts/dependencies/templates/minio-restore-cronjob.yaml
+++ b/charts/dependencies/templates/minio-restore-cronjob.yaml
@@ -1,4 +1,5 @@
-{{ if and .Values.minio.enabled .Values.restore.enabled }}
+{{ if and .Values.minio.enabled (eq (include "minio.restore_enabled" .) "true") }}
+{{- if eq .Values.minio.restore.type "dump" }}
 ---
 apiVersion: batch/v1
 {{ if .Values.restore.cronjob }}
@@ -62,7 +63,7 @@ spec:
                       name: {{ .Values.restore.backup_server_secret }}
                       key: host
                 - name: BACKUP_REMOTE_DIR
-                  value: "{{ .Values.minio.backup_server_dir | default .Values.restore.backup_server_dir }}"
+                  value: {{ default .Values.restore.backup_server_dir .Values.minio.backup_server_dir }}
               {{- include "render-env-vars" (dict "service_name" "restore" "Values" .Values) | nindent 4 }}
               volumeMounts:
                 - name: backup-ssh-key
@@ -82,4 +83,38 @@ spec:
               configMap:
                 name: minio-scripts
                 defaultMode: 0755
+{{- end }}
+{{- if eq .Values.minio.restore.type "mirror" }}
+---
+apiVersion: batch/v1
+{{ if .Values.restore.cronjob }}
+kind: CronJob
+{{- else }}
+kind: Job
+{{- end }}
+metadata:
+  name: minio-restore
+spec:
+  {{ if .Values.restore.cronjob }}
+  schedule: {{ default .Values.restore.schedule .Values.minio.restore.schedule }}
+  {{- if .Values.timezone }}
+  timeZone: {{ .Values.timezone }}
+  {{- end }}
+  jobTemplate:
+    spec:
+  {{- end }}
+      template:
+        spec:
+          serviceAccountName: backup-runner
+          containers:
+            - name: runner
+              image: bitnami/kubectl:latest
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  kubectl exec minio-0 -c rsync -- \
+                    /bin/sh -c "rsync -avz -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' \$BACKUP_USER@\$BACKUP_HOST:\$BACKUP_REMOTE_DIR/minio/ /data"
+          restartPolicy: OnFailure
+{{- end }}
 {{- end }}

--- a/charts/dependencies/templates/minio.yaml
+++ b/charts/dependencies/templates/minio.yaml
@@ -138,6 +138,42 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: minio
+      {{- if eq (include "minio.use_mirror" .) "true" }}
+        - image: eeacms/rsync:3.0
+          name: rsync
+          command: ["sleep", "infinity"]
+          env:
+            - name: BACKUP_USER
+              valueFrom:
+                secretKeyRef:
+                {{- if (eq (include "minio.backup_enabled" .) "true") }}
+                  name: {{ default .Values.backup.backup_server_secret .Values.minio.backup.server_secret}}
+                {{- else }}
+                  name: {{ default .Values.restore.backup_server_secret .Values.minio.restore.server_secret}}
+                {{- end }}
+                  key: user
+            - name: BACKUP_HOST
+              valueFrom:
+                secretKeyRef:
+                {{- if (eq (include "minio.backup_enabled" .) "true") }}
+                  name: {{ default .Values.backup.backup_server_secret .Values.minio.backup.server_secret}}
+                {{- else }}
+                  name: {{ default .Values.restore.backup_server_secret .Values.minio.restore.server_secret}}
+                {{- end }}
+                  key: host
+            - name: BACKUP_REMOTE_DIR
+              {{- if (eq (include "minio.backup_enabled" .) "true") }}
+              value: {{ default .Values.backup.backup_server_dir .Values.minio.backup.server_dir }}
+              {{- else }}
+              value: {{ default .Values.restore.backup_server_dir .Values.minio.restore.server_dir }}
+              {{- end }}
+          volumeMounts:
+            - mountPath: /data
+              name: minio
+            - name: backup-ssh-key
+              mountPath: /root/.ssh
+              readOnly: true
+      {{- end }}
       restartPolicy: Always
       volumes:
         - name: minio
@@ -148,5 +184,20 @@ spec:
           hostPath:
             path: {{ .Values.minio.host_data_path | default "/data/minio" }}
             type: DirectoryOrCreate
+      {{- end }}
+      {{- if eq (include "minio.use_mirror" .) "true" }}
+      # If backup or restore enabled -> Define key for backup
+      {{- $ssh_secret := default .Values.backup.backup_server_secret .Values.minio.backup.server_secret }}
+      # If restore enabled -> use key for restore
+      {{- if (eq (include "minio.restore_enabled" .) "true") }}
+      {{- $ssh_secret = default .Values.restore.backup_server_secret .Values.minio.restore.server_secret }}
+      {{- end }}
+        - name: backup-ssh-key
+          secret:
+            secretName: {{ $ssh_secret }}
+            defaultMode: 0400
+            items:
+              - key: ssh_key
+                path: id_rsa
       {{- end }}
 {{- end }}

--- a/charts/dependencies/templates/postgres-backup-cronjob.yaml
+++ b/charts/dependencies/templates/postgres-backup-cronjob.yaml
@@ -114,7 +114,7 @@ spec:
   {{- end }}
       template:
         spec:
-          serviceAccountName: postgres-backup-runner
+          serviceAccountName: backup-runner
           containers:
             - name: runner
               image: bitnami/kubectl:latest
@@ -158,7 +158,7 @@ spec:
   {{- end }}
       template:
         spec:
-          serviceAccountName: postgres-backup-runner
+          serviceAccountName: backup-runner
           containers:
             - name: runner
               image: bitnami/kubectl:latest

--- a/charts/dependencies/templates/postgres-restore-cronjob.yaml
+++ b/charts/dependencies/templates/postgres-restore-cronjob.yaml
@@ -113,7 +113,7 @@ spec:
   {{- end }}
       template:
         spec:
-          serviceAccountName: postgres-backup-runner
+          serviceAccountName: backup-runner
           containers:
             - name: runner
               image: bitnami/kubectl:latest

--- a/charts/dependencies/templates/postgres.yaml
+++ b/charts/dependencies/templates/postgres.yaml
@@ -148,9 +148,9 @@ spec:
               name: data
             - name: postgres-run
               mountPath: /run/postgresql
-          {{- if (eq (include "postgres.use_pgBackRest" .) "true") }}
             - name: init-script
               mountPath: /docker-entrypoint-initdb.d
+          {{- if (eq (include "postgres.use_pgBackRest" .) "true") }}
             - name: pgbackrest-config
               mountPath: /etc/pgbackrest
             - name: pgbackrest-ssh

--- a/charts/dependencies/values.yaml
+++ b/charts/dependencies/values.yaml
@@ -175,20 +175,55 @@ elastalert:
   env: {}
 
 minio:
-  # Enable MinIO deployment.
+  # Enable or disable MinIO deployment.
   enabled: true
-  # minio defaults to minioadmin and minioadmin as the access key and secret key respectively.
-  # MinIO strongly discourages use of the default credentials regardless of deployment environment.
-  # Check official documentation for more details:
+
+  # Use default credentials (username: minioadmin, password: minioadmin).
+  # Highly discouraged for production environments—see official docs:
   # https://min.io/docs/minio/linux/administration/identity-access-management/minio-user-management.html
   use_default_credentials: true
-  # If set to `false`, then MinIO will be deployed with authentication enabled.
-  # Secret with random credentials will be created with name `minio-opencrvs-users`.
-  # Secret will contain following variables:
-  # - MINIO_ACCESS_KEY
-  # - MINIO_SECRET_KEY
-  # - MINIO_ROOT_USER, same as MINIO_ACCESS_KEY
-  # - MINIO_ROOT_PASSWORD, same as MINIO_SECRET_KEY
+
+  # storage_type: host_path
+
+  # Path to persistent data on the VM (when storage_type is host_path).
+  host_data_path: /data/minio
+
+  # Node selector for MinIO pods, usually used to keep data persistent on specified nodes.
+  node_selector: {}
+
+  backup:
+    # Enable or disable backup functionality for MinIO.
+    enabled: false
+
+    # Backup type:
+    # "dump" - creates a full filesystem dump;
+    # "mirror" - mirrors the filesystem to a remote backup server.
+    type: dump
+
+    # Name of the Kubernetes secret containing backup server SSH credentials.
+    # server_secret: backup-server-ssh-credentials
+
+    # Cron schedule to run backup job (format: "MIN HOUR DAY MONTH WEEKDAY").
+    # schedule: "0 1 * * *"
+
+    # Directory on backup server where encrypted backups are stored.
+    # If not set, use global backup_server_dir.
+    # server_dir: "n/a"
+
+  restore:
+    # Enable or disable restore functionality for MinIO.
+    enabled: false
+
+    # Restore type:
+    # "dump" - restore from encrypted archive;
+    # "mirror" - mirror filesystem from remote backup server.
+    type: dump
+
+    # Name of the Kubernetes secret containing backup server SSH credentials.
+    # server_secret: backup-server-ssh-credentials
+
+    # Cron schedule for restore job.
+    # schedule: "0 3 * * *"
 
 redis:
   # Enable Redis deployment.


### PR DESCRIPTION


## Testing

### Backup
Upload new file to production MinIO server:
<img width="1425" height="498" alt="image" src="https://github.com/user-attachments/assets/3676fc9c-f654-4269-a254-3b95b32b74ba" />

Create job:
```
k create job --from cronjob/minio-backup minio-backup1
```
Verify file was transferred to backup:
<img width="856" height="147" alt="image" src="https://github.com/user-attachments/assets/95cd8d05-1b6d-45e4-873e-3c47708ef01f" />


### Restore

Create restore job:
```
k create job --from cronjob/minio-restore minio-restore1
```

Verify file was transferred to staging:

<img width="727" height="155" alt="image" src="https://github.com/user-attachments/assets/754ebbcf-36fd-4f3d-aca6-ee7d8027a2b4" />

<img width="1422" height="512" alt="image" src="https://github.com/user-attachments/assets/c3bfc77b-fb09-4491-9c9b-d8710c88bfc2" />
