### PR TITLE
fix: Add clear message warning to reset job

### DIFF
--- a/.github/workflows/k8s-reset-data.yml
+++ b/.github/workflows/k8s-reset-data.yml
@@ -29,6 +29,13 @@ jobs:
           minimum-approvals: 3
           issue-title: "Reset environment (${{ inputs.environment }})"
           issue-body: >
+            3 separate users must approve to reset data on production.
+            
+            > [!WARNING]
+            > **Are you sure what you are doing?**
+            
+            **You are clearing all CITIZENS data on production!!**
+
             Please approve or deny ${{ inputs.environment }} environment reset 
             initiated from GitHub Actions by @${{ github.actor }}.
 


### PR DESCRIPTION
Small fix for more clear reset workflow

<img width="930" height="299" alt="image" src="https://github.com/user-attachments/assets/79814899-5bd1-4b6f-9316-40d5b97a9561" />
