### PR TITLE
fix: Replace truncate with fallocate

### DIFF
--- a/infrastructure/cryptfs/bootstrap.sh
+++ b/infrastructure/cryptfs/bootstrap.sh
@@ -47,7 +47,7 @@ if test -f "$FS_FILE"; then
   echo "ERROR: $FS_FILE exists, cannot bootstrap as the file might already contain existing data. Try run mount.sh to mount the file."
   exit 1
 else
-  truncate -s $FS_SIZE $FS_FILE
+  fallocate -l $FS_SIZE $FS_FILE
 fi
 
 # create a loop device from the data file


### PR DESCRIPTION
# Description

- related issue: https://github.com/opencrvs/opencrvs-core/issues/6325

## Problem definition

Command used to allocate file for encrypted file system:
```
truncate -s 50g /cryptfs_file_sparse.img
```

A sparse file is a type of file in Unix/Linux where parts of the file are not actually stored on disk; instead, those ranges are marked as empty (zero) and only use disk space when real data is written to them.

```
vmudryi@tmp-prod1:~$ du -sh /cryptfs_file_sparse.img 
36G     /cryptfs_file_sparse.img
vmudryi@tmp-prod1:~$ ls -lh /cryptfs_file_sparse.img 
-rw-r--r-- 1 root root 50G Feb 25 08:09 /cryptfs_file_sparse.img
```

## Improvement

Replace `truncate` with `fallocate`. The syntax is very similar, and you can use the same variables, making the transition almost seamless.

Place for fix: https://github.com/opencrvs/infrastructure/blob/develop/infrastructure/cryptfs/bootstrap.sh#L50

Replace:
```
truncate -s $FS_SIZE $FS_FILE
```
with
```
fallocate -l $FS_SIZE $FS_FILE
```

# Benefits

With this improvement we will avoid issue with full filesystem.

# Testing

Run fallocate on existing filesystem:

<img width="686" height="215" alt="image" src="https://github.com/user-attachments/assets/a76047cd-dc54-48af-94d3-2656a78aebca" />
