### PR TITLE
fix: Added check to avoid bootstrap if free file system size is lower…

### DIFF
--- a/infrastructure/server-setup/group_vars/all.yml
+++ b/infrastructure/server-setup/group_vars/all.yml
@@ -19,6 +19,8 @@ backup_server_user_home: '/home/backup'
 # Disk Encryption key location as an example (in production use a hardware security module)
 disk_encryption_key_path: /root/disk-encryption-key.txt
 
+# Minimum required disk space for successful kubernetes deployment
+min_free_disk_size: "30g"
 # Kubernetes components versions:
 # - kubeadm
 # - kubelet

--- a/infrastructure/server-setup/tasks/k8s/data-partition.yml
+++ b/infrastructure/server-setup/tasks/k8s/data-partition.yml
@@ -5,6 +5,38 @@
   register: encryptedFileSystemPreCheck
   when: disk_encryption_key is defined
 
+- name: Get free disk space
+  ansible.builtin.shell: |
+    df --block-size=G --output=avail / | grep -oP '[0-9]+'
+  register: free_disk_size_result
+  when:
+    - disk_encryption_key is defined
+    - not encryptedFileSystemPreCheck.stat.exists
+
+- name: Normalize file size units (handles G, g, Gb, GB, etc.)
+  set_fact:
+    free_disk_size: "{{ free_disk_size_result.stdout | int  }}"
+    encrypted_file_size: "{{ encrypted_disk_size | regex_replace('[^0-9]', '') | int }}"
+    min_free_disk_size: "{{ min_free_disk_size | regex_replace('[^0-9]', '') | int }}"
+  when:
+    - disk_encryption_key is defined
+    - not encryptedFileSystemPreCheck.stat.exists
+
+- name: Calculate total required space (in GB)
+  set_fact:
+    required_size: "{{ encrypted_file_size + min_free_disk_size }}"
+  when:
+    - disk_encryption_key is defined
+    - not encryptedFileSystemPreCheck.stat.exists
+
+- name: Fail if not enough free space
+  fail:
+    msg: "Not enough free disk space! Required: {{ required_size }}G, Free: {{ free_disk_size }}G"
+  when:
+    - free_disk_size < required_size
+    - disk_encryption_key is defined
+    - not encryptedFileSystemPreCheck.stat.exists
+
 - name: 'Bootstrap encrypted data folder'
   script: ../cryptfs/bootstrap.sh -s {{ encrypted_disk_size }} -p {{ disk_encryption_key }}
   when:


### PR DESCRIPTION
# Description

- related issue: https://github.com/opencrvs/opencrvs-core/issues/6325
- related PR: https://github.com/opencrvs/infrastructure/pull/253

## Misconfiguration example

### Preconditions

- `/` root partition size 100G
- `/cryptfs_file_sparse.img` allocated size 300G

### Incident details

Root partition (`/`) was initially smaller then `/cryptfs_file_sparse.img` size.

MongoDB was not able to start properly
```
opencrvs_mongo1.1.iuzpvbufoaej@ercvs-staging    | find: '/data/db/WiredTiger.turtle': Structure needs cleaning
opencrvs_mongo1.1.iuzpvbufoaej@ercvs-staging    | chown: cannot access '/data/db/WiredTiger.turtle': Structure needs cleaning
opencrvs_mongo1.1.8mjamgcklrj5@ercvs-staging    | find: '/data/db/WiredTiger.turtle': Structure needs cleaning
opencrvs_mongo1.1.zpxrpp9me1w8@ercvs-staging    | find: '/data/db/WiredTiger.turtle': Structure needs cleaning
opencrvs_mongo1.1.8mjamgcklrj5@ercvs-staging    | chown: cannot access '/data/db/WiredTiger.turtle': Structure needs cleaning
opencrvs_mongo1.1.zpxrpp9me1w8@ercvs-staging    | chown: cannot access '/data/db/WiredTiger.turtle': Structure needs cleaning
opencrvs_mongo1.1.phkbcct2sxjg@ercvs-staging    | find: '/data/db/WiredTiger.turtle': Structure needs cleaning
opencrvs_mongo1.1.phkbcct2sxjg@ercvs-staging    | chown: cannot access '/data/db/WiredTiger.turtle': Structure needs cleaning
```

Corrupted data on file system
```
root@ercvs-staging:/home/oquimson# ls -al /data/mongo/
ls: cannot access '/data/mongo/WiredTiger.turtle': Structure needs cleaning
total 24
drwxr-xr-x  2 lxd  root   20480 Jan 16 18:07 .
drwxr-xr-x 14 root root    4096 Jan 16 17:15 ..
-rw-------  1 lxd  docker     0 Oct  1 17:46 .dbshell
-?????????  ? ?    ?          ?            ? WiredTiger.turtle
```

# Fix applied

- [x] Add check `/` > `/data` + 30G (Minimum required disk space for successful kubernetes deployment)
- [x] Add configuration option to make encryption optional: See documentation for OpenCRVS v2.0