### PR TITLE
fix: Added eviction policy configuration

### DIFF
--- a/infrastructure/server-setup/group_vars/all.yml
+++ b/infrastructure/server-setup/group_vars/all.yml
@@ -27,6 +27,29 @@ min_free_disk_size: "30g"
 # - kubectl
 kubernetes_version: "v1.34"
 
+# Kubernetes Eviction Policy Configuration
+#
+# By default, Kubernetes uses percentage thresholds to trigger disk evictions.
+# OpenCRVS servers often have large disk partitions, so specifying absolute disk
+# sizes is more effective and makes disk management predictable.
+#
+# OpenCRVS recommends:
+#   - Keeping at least 10GiB of free disk space for safe upgrades and stable operation.
+#   - Using absolute values for eviction thresholds to avoid unnecessary evictions or outages.
+#
+# The settings below define the minimum free disk space (in GiB) required before Kubernetes will start evicting pods.
+# NOTE: Even if root (/) and container images are located on the same partition both policies must be explicitly defined
+# --- Hard Eviction Thresholds ---
+# If free disk space drops below this value, Kubernetes immediately evicts pods to free up space.
+eviction_hard_nodefs: "10Gi"          # Minimum free space on root (/) filesystem
+eviction_hard_imagefs: "10Gi"         # Minimum free space for container images
+
+# --- Soft Eviction Thresholds ---
+# If free disk space stays below this value for a sustained period, Kubernetes will evict pods gradually.
+eviction_soft_nodefs: "20Gi"          # Minimum free space on root (/) filesystem over time
+eviction_soft_imagefs: "20Gi"         # Minimum free space for container images over time
+
+
 # Container Network Interface plugin: Calico version
 calico_version: "v3.26.1"
 # CNI configuration

--- a/infrastructure/server-setup/k8s.yml
+++ b/infrastructure/server-setup/k8s.yml
@@ -119,10 +119,24 @@
       tags:
         - users
         - k8s
-- name: Setup Kubernetes Cluster UFW
+- name: Common Kubernetes post configuration tasks
   hosts: master, workers
   become: yes
   gather_facts: yes
   tasks:
-    - name: Run UFW
-      include_tasks: tasks/k8s/ufw.yml
+    - name: Setup kubelet eviction policies
+      include_tasks:
+        file: tasks/k8s/eviction-policy.yml
+        apply:
+          tags:
+            - k8s
+      tags:
+        - k8s
+    - name: Configure UFW rules
+      include_tasks:
+        file: tasks/k8s/ufw.yml
+        apply:
+          tags:
+            - k8s
+      tags:
+        - k8s

--- a/infrastructure/server-setup/tasks/k8s/eviction-policy.yml
+++ b/infrastructure/server-setup/tasks/k8s/eviction-policy.yml
@@ -1,0 +1,22 @@
+- name: Insert OpenCRVS eviction policies
+  blockinfile:
+    path: /var/lib/kubelet/config.yaml
+    block: |
+      evictionHard:
+        nodefs.available: "{{ eviction_hard_nodefs }}"
+        imagefs.available: "{{ eviction_hard_imagefs }}"
+
+      evictionSoft:
+        nodefs.available: "{{ eviction_soft_nodefs }}"
+        imagefs.available: "{{ eviction_soft_imagefs }}"
+      evictionSoftGracePeriod:
+        nodefs.available: "1h"
+        imagefs.available: "1h"
+    marker: "# {mark} OpenCRVS EVICTION POLICY"
+  register: kubelet_eviction_update
+
+- name: Restart kubelet if config changed
+  systemd:
+    name: kubelet
+    state: restarted
+  when: kubelet_eviction_update.changed


### PR DESCRIPTION
# Description

This PR aims to avoid early pod eviction on large root (/) partitions.

By default Kubernetes has eviction policies configured based on used disk percentage. For large disk partitions its better to use GB.

Related issue: https://github.com/opencrvs/opencrvs-core/issues/6325

Related PRs:
- https://github.com/opencrvs/infrastructure/pull/254
- https://github.com/opencrvs/infrastructure/pull/253

# Testing

Provision example: https://github.com/adskyiproger/opencrvs-infrastructure/actions/runs/22402088704/job/64856816314

## Apply configuration to new setup

Configuration successfully applied
<img width="429" height="235" alt="image" src="https://github.com/user-attachments/assets/d567e1a4-ad66-4171-9e59-08f1a7c3144d" />



## Apply configuration to manually updated kubelet

Expectation:
- evictionHard and evictionSoft will be present as duplicated
- last configuration section from file will be applied

After provision duplicate section will appear:
<img width="589" height="285" alt="image" src="https://github.com/user-attachments/assets/5d44efcf-5980-4a3a-95c3-ca8e6c139f5d" />

Last configuration from yaml file will be applied:
<img width="852" height="521" alt="image" src="https://github.com/user-attachments/assets/968970bf-6dab-4352-97b0-cab78d05380a" />


## Testing eviction rules

Preconditions: Initial environment configuration has hard fs space set to 5G

Goal: Pods should be evicted after running provision workflow

Before running provision

```yaml
evictionHard:
  nodefs.available: "5Gi"
  imagefs.available: "5Gi"
```
<img width="692" height="430" alt="image" src="https://github.com/user-attachments/assets/3cef700d-984e-495a-95c8-90a17626252e" />
<img width="774" height="184" alt="image" src="https://github.com/user-attachments/assets/41f67c84-0bd9-40a3-8cf4-bd9fa805cb00" />

After running provision workflow:
