### PR TITLE
fix: Make /cryptfs_file_sparse.img file path configurable

### DIFF
--- a/infrastructure/server-setup/group_vars/all.yml
+++ b/infrastructure/server-setup/group_vars/all.yml
@@ -19,6 +19,9 @@ backup_server_user_home: '/home/backup'
 # Disk Encryption key location as an example (in production use a hardware security module)
 disk_encryption_key_path: /root/disk-encryption-key.txt
 
+# Path to encrypted file with citizens data
+data_file_path: /cryptfs_file_sparse.img
+
 # Minimum required disk space for successful kubernetes deployment
 min_free_disk_size: "30g"
 # Kubernetes components versions:

--- a/infrastructure/server-setup/tasks/k8s/data-partition.yml
+++ b/infrastructure/server-setup/tasks/k8s/data-partition.yml
@@ -1,6 +1,6 @@
 - name: 'Precheck if encrypted file system exists so we dont try to bootstrap'
   stat:
-    path: /cryptfs_file_sparse.img
+    path: "{{ data_file_path }}"
     get_checksum: False
   register: encryptedFileSystemPreCheck
   when: disk_encryption_key is defined
@@ -40,25 +40,25 @@
     - free_disk_size < required_size
 
 - name: 'Bootstrap encrypted data folder'
-  script: ../cryptfs/bootstrap.sh -s {{ encrypted_disk_size }} -p {{ disk_encryption_key }}
+  script: ../cryptfs/bootstrap.sh -s {{ encrypted_disk_size }} -p {{ disk_encryption_key }} -f {{ data_file_path }}
   when:
     - disk_encryption_key is defined
     - not encryptedFileSystemPreCheck.stat.exists
 
 - name: Wait for encrypted file system
   ansible.builtin.wait_for:
-    path: /cryptfs_file_sparse.img
+    path: "{{ data_file_path }}"
     state: present
   when: disk_encryption_key is defined
 
 - name: 'Register encrypted file system'
   stat:
-    path: /cryptfs_file_sparse.img
+    path: "{{ data_file_path }}"
     get_checksum: False
   register: encryptedFileSystemPostCheck
   when: disk_encryption_key is defined
 
-- name: Check if cryptfs_file_sparse.img is already mounted
+- name: Check if encrypted disk is already mounted
   shell: mount | grep -q 'cryptfs on /data'
   register: is_mounted
   ignore_errors: true
@@ -66,7 +66,7 @@
   when: disk_encryption_key is defined
 
 - name: 'Mount encrypted data folder'
-  script: ../cryptfs/mount.sh -p {{ disk_encryption_key }}
+  script: ../cryptfs/mount.sh -p {{ disk_encryption_key }} -f {{ data_file_path }}
   when:
     - disk_encryption_key is defined
     - encryptedFileSystemPostCheck.stat.exists

--- a/infrastructure/server-setup/tasks/k8s/decrypt-on-boot.yml
+++ b/infrastructure/server-setup/tasks/k8s/decrypt-on-boot.yml
@@ -6,7 +6,7 @@
 
 - name: 'Register encrypted file system'
   stat:
-    path: /cryptfs_file_sparse.img
+    path: "{{ data_file_path }}"
     get_checksum: False
   register: encryptedFileSystemPostCheck
   when: disk_encryption_key is defined
@@ -71,7 +71,7 @@
       Description=Mount encrypted dir
 
       [Service]
-      ExecStart=bash /opt/opencrvs/scripts/cryptfs/decrypt.sh -key {{ disk_encryption_key_path }} >> /var/log/cryptfs-reboot.log 2>&1
+      ExecStart=bash /opt/opencrvs/scripts/cryptfs/decrypt.sh -key {{ disk_encryption_key_path }} -f {{ data_file_path }} >> /var/log/cryptfs-reboot.log 2>&1
 
       [Install]
       WantedBy=multi-user.target

--- a/infrastructure/server-setup/tasks/k8s/validate-data-partition.yml
+++ b/infrastructure/server-setup/tasks/k8s/validate-data-partition.yml
@@ -3,7 +3,7 @@
   block:
     - name: Backup LUKS header
       shell: |
-        loop_device=$(losetup -j /cryptfs_file_sparse.img | cut -d: -f1)
+        loop_device=$(losetup -j {{ data_file_path }} | cut -d: -f1)
         rm -vf /tmp/luks-header.img
         cryptsetup luksHeaderBackup $loop_device --header-backup-file /tmp/luks-header.img
 


### PR DESCRIPTION
## Description

Original PR: https://github.com/opencrvs/opencrvs-countryconfig/pull/1227

Related issue: https://github.com/opencrvs/opencrvs-core/issues/6325

In some cases it's useful to have custom path to /cryptfs_file_sparse.img. E/g instead of using default path we could use /var/cryptfs_file_sparse.img

Thanks @oni-on1003 for help with implementation