### PR TITLE
fix: Disable notification transport selection (default: email)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 branch=$(git rev-parse --abbrev-ref HEAD)
-pattern='^[a-z][a-z0-9\/\-\.]{1,29}$'
+pattern='^[a-z][-a-z0-9/.]{1,29}$'
 
 if [[ ! "$branch" =~ $pattern ]]; then
   echo """

--- a/infrastructure/environments/derived-variables.ts
+++ b/infrastructure/environments/derived-variables.ts
@@ -153,4 +153,11 @@ export const derivedVariables = [
     type: 'disabled',
     scope: 'ENVIRONMENT'
   },
+  {
+    name: 'NOTIFICATION_TRANSPORT',
+    valueLabel: 'NOTIFICATION_TRANSPORT',
+    valueType: 'VARIABLE',
+    type: 'disabled',
+    scope: 'ENVIRONMENT'
+  },
 ] as const;

--- a/infrastructure/environments/questions.ts
+++ b/infrastructure/environments/questions.ts
@@ -145,7 +145,7 @@ export const infrastructureQuestions = [
     valueType: 'VARIABLE' as const,
     // validate: notEmpty,
     valueLabel: 'KUBE_API_HOST',
-    initial: process.env.KUBE_API_HOST || '',
+    initial: process.env.KUBE_API_HOST,
     scope: 'ENVIRONMENT' as const
   },
   {
@@ -156,7 +156,7 @@ export const infrastructureQuestions = [
     valueType: 'VARIABLE' as const,
     // validate: notEmpty,
     valueLabel: 'WORKER_NODES',
-    initial: process.env.WORKER_NODES || '',
+    initial: process.env.WORKER_NODES,
     scope: 'ENVIRONMENT' as const,
   },
 ]

--- a/infrastructure/environments/setup-environment.ts
+++ b/infrastructure/environments/setup-environment.ts
@@ -1322,12 +1322,12 @@ ALL_QUESTIONS.push(
       `➡️ ${kleur.bold().yellow('Run following command on Kubernetes worker VM to create provision user and setup SSH key:')}\n` +
       "\n" +
       "curl -sfL https://raw.githubusercontent.com/opencrvs/infrastructure/refs/heads/develop/scripts/bootstrap/opencrvs-bootstrap.sh -o opencrvs-bootstrap.sh && \\ \n" +
-      `bash opencrvs-bootstrap.sh --ssh-public-key ${kleur.bold('[PUT PROVISION USER PUBLIC KEY FROM MASTER NODE]')}\n` : ""
+      `bash opencrvs-bootstrap.sh --ssh-public-key "${kleur.bold('[PUT PROVISION USER PUBLIC KEY FROM MASTER NODE]')}"\n` : ""
 
     addon_message += configureBackup ? 
       `\n➡️ ${kleur.bold().yellow('Run following command on backup server to create provision user and setup SSH key:')}\n` +
       "curl -sfL https://raw.githubusercontent.com/opencrvs/infrastructure/refs/heads/develop/scripts/bootstrap/opencrvs-bootstrap.sh -o opencrvs-bootstrap.sh && \\ \n" +
-      `bash opencrvs-bootstrap.sh --ssh-public-key ${kleur.bold('[PUT PROVISION USER PUBLIC KEY FROM MASTER NODE]')}` : ""
+      `bash opencrvs-bootstrap.sh --ssh-public-key "${kleur.bold('[PUT PROVISION USER PUBLIC KEY FROM MASTER NODE]')}"` : ""
 
   log(`
 ${kleur.yellow('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━')}

--- a/infrastructure/environments/setup-environment.ts
+++ b/infrastructure/environments/setup-environment.ts
@@ -45,8 +45,6 @@ import {
   databaseAndMonitoringQuestions,
   diskQuestions,
   sentryQuestions,
-  notificationTransportQuestions,
-  smsQuestions,
   emailQuestions,
   metabaseAdminQuestions,
   backupQuestions,
@@ -265,8 +263,6 @@ ALL_QUESTIONS.push(
   ...backupQuestions,
   ...countryQuestions,
   ...databaseAndMonitoringQuestions,
-  ...notificationTransportQuestions,
-  ...smsQuestions,
   ...emailQuestions,
   ...sentryQuestions,
   ...derivedVariables,
@@ -626,19 +622,6 @@ ALL_QUESTIONS.push(
     log('\n', kleur.bold().underline('SMTP'))
     await promptAndStoreAnswer(environment, emailQuestions, existingValues)
 
-    log('\n', kleur.bold().underline('Notification'))
-
-    const { notificationTransport } = await promptAndStoreAnswer(
-      environment,
-      notificationTransportQuestions,
-      existingValues
-    )
-
-    if (notificationTransport.includes('sms')) {
-      await promptAndStoreAnswer(environment, smsQuestions, existingValues)
-    }
-
-
     const allAnswers = ALL_ANSWERS.reduce((acc, answer) => {
       return { ...acc, ...answer }
     })
@@ -683,6 +666,23 @@ ALL_QUESTIONS.push(
         scope: 'REPOSITORY' as const
       },
     ]
+    derivedUpdates.push({
+        name: 'NOTIFICATION_TRANSPORT',
+        type: 'VARIABLE' as const,
+        didExist: findExistingValue(
+          'NOTIFICATION_TRANSPORT',
+          'VARIABLE',
+          'ENVIRONMENT',
+          existingValues
+        ),
+        value: findExistingOrDefine(
+          'NOTIFICATION_TRANSPORT',
+          'VARIABLE',
+          'ENVIRONMENT',
+          'email'
+        ),
+        scope: 'ENVIRONMENT' as const
+      })
     derivedUpdates.push(...ssl_answers)
     if (configureBackup) {
       derivedUpdates.push({

--- a/infrastructure/environments/templates/charts-values/dependencies/values.yaml
+++ b/infrastructure/environments/templates/charts-values/dependencies/values.yaml
@@ -6,11 +6,17 @@
 # make sure your custom changes doesn't conflict with values.yaml
 ##################################################################################
 
+# Default: storage_type: host_path
+# host_path option is backward compatible with Docker Swarm,
+# configured to use sub-directories within /data folder
+# For new installations feel free to remove storage_type
 storage_type: host_path
+
+# All datastores are placed on first node (master1) for backward compatibility
+# with Docker Swarm.
+# For new installations feel free to remove node_selector
 node_selector:
   role: data1
-
-environment_type: {{environment_type}}
 
 minio:
   use_default_credentials: false


### PR DESCRIPTION
# Description

The goal of this PR is to disable NOTIFICATION_TRANSPORT question

# Testing


## NOTIFICATION_TRANSPORT is not defined

If notification transport was not defined before then variable will be added:

<img width="650" height="52" alt="image" src="https://github.com/user-attachments/assets/356ac7db-bb16-4e95-a6ea-d5b7cf1cca16" />


## NOTIFICATION_TRANSPORT is set as email (existing configuration)

Nothing will happen. The script will skip NOTIFICATION_TRANSPORT update

## NOTIFICATION_TRANSPORT is defined as sms (existing configuration)

User manually defined NOTIFICATION_TRANSPORT as sms

Nothing will happen. The script will skip NOTIFICATION_TRANSPORT update
