### PR TITLE
fix: Enable UFW

### DIFF
--- a/infrastructure/server-setup/tasks/k8s/ufw.yml
+++ b/infrastructure/server-setup/tasks/k8s/ufw.yml
@@ -42,8 +42,17 @@
     - { port: 30443, proto: "tcp" }  # NodePort HTTPS
   ignore_errors: yes
 
+- name: "Allow traffic on Calico interfaces"
+  community.general.ufw:
+    rule: allow
+    interface_in: "{{ item }}"
+  loop:
+    - cali+
+    - vxlan.calico
+  ignore_errors: yes
+
 - name: "Enable UFW with deny by default"
   ufw:
-    state: disabled
+    state: enabled
     default: deny
     direction: incoming


### PR DESCRIPTION
# Description

UFW was disabled before testing on multiple-nodes Kubernetes cluster was performed

Time to enable it


# Testing

Provision: https://github.com/adskyiproger/opencrvs-infrastructure/actions/runs/23199751120

Dependencies deployment: https://github.com/adskyiproger/opencrvs-infrastructure/actions/runs/23200151976

OpenCRVS Deployment: https://github.com/adskyiproger/opencrvs-infrastructure/actions/runs/23200764422