### PR TITLE
fix: Disable data_seed by default on first deployment

### DIFF
--- a/.github/workflows/deploy-opencrvs.yml
+++ b/.github/workflows/deploy-opencrvs.yml
@@ -22,9 +22,9 @@ on:
         required: true
         default: "v1.9.10"
       data-seed-enabled:
-        description: "Enable data seeding during deployment"
+        description: "Data seeding during deployment"
         required: false
-        default: "true"
+        default: "false"
         type: boolean
       environment:
         description: "Target environment"


### PR DESCRIPTION
Related issue: https://github.com/opencrvs/opencrvs-core/issues/12097

# Testing

Make sure data_seed checkbox is not enabled by default:
<img width="1298" height="512" alt="image" src="https://github.com/user-attachments/assets/d463bd6e-a753-4806-8b1c-5d859b6d77f4" />

Documentation updated:
<img width="842" height="870" alt="image" src="https://github.com/user-attachments/assets/a73ab8f3-d157-44fa-9377-a04a0e8c303c" />

