### PR TITLE
Run traefik as daemonset

### DIFF
--- a/infrastructure/environments/templates/charts-values/traefik/values.yaml
+++ b/infrastructure/environments/templates/charts-values/traefik/values.yaml
@@ -99,6 +99,9 @@ tlsStore:
 
 deployment:
   hostNetwork: true
+  {{#if static_ssl}}
+  kind: DaemonSet
+  {{/if}}
   {{#if lets_encrypt}}
   additionalVolumes:
     - name: acme
@@ -106,6 +109,8 @@ deployment:
         path: /data/traefik
   {{/if}}
 
-
+# If you need to run traefik on all cluster nodes
+# Add this line to traefik/values.override.yaml
+# nodeSelector: {}
 nodeSelector:
   traefik-role: ingress


### PR DESCRIPTION
Related issue: https://github.com/opencrvs/opencrvs-core/issues/11762

Running traefik as daemonset will allow us scale up horizontally without taking care about port allocation or anything else.