### PR TITLE
fix(config): remove deprecated QA_ENV template variable

### DIFF
--- a/infrastructure/environments/setup-environment.ts
+++ b/infrastructure/environments/setup-environment.ts
@@ -1303,7 +1303,7 @@ ALL_QUESTIONS.push(
         // FIXME: In general that should be environment_type,
         // Hardcode like this blocks us from being generic:
         // https://github.com/opencrvs/opencrvs-core/issues/11171
-        is_qa_env: environment !== 'production' ? true : false,
+        two_fa_enabled: environment !== 'production' ? true : false,
         backup_enabled: configureBackup ? true : false,
         restore_enabled: restoreEnvironmentName ? true : false,
         restore_environment_name: restoreEnvironmentName || "",

--- a/infrastructure/environments/setup-environment.ts
+++ b/infrastructure/environments/setup-environment.ts
@@ -1303,7 +1303,6 @@ ALL_QUESTIONS.push(
         // FIXME: In general that should be environment_type,
         // Hardcode like this blocks us from being generic:
         // https://github.com/opencrvs/opencrvs-core/issues/11171
-        is_qa_env: environment !== 'production' ? true : false,
         backup_enabled: configureBackup ? true : false,
         restore_enabled: restoreEnvironmentName ? true : false,
         restore_environment_name: restoreEnvironmentName || "",

--- a/infrastructure/environments/setup-environment.ts
+++ b/infrastructure/environments/setup-environment.ts
@@ -1303,7 +1303,7 @@ ALL_QUESTIONS.push(
         // FIXME: In general that should be environment_type,
         // Hardcode like this blocks us from being generic:
         // https://github.com/opencrvs/opencrvs-core/issues/11171
-        two_fa_enabled: environment !== 'production' ? true : false,
+        two_fa_enabled: environment !== 'production' ? false : true,
         backup_enabled: configureBackup ? true : false,
         restore_enabled: restoreEnvironmentName ? true : false,
         restore_environment_name: restoreEnvironmentName || "",

--- a/infrastructure/environments/swarm-to-k8s.ts
+++ b/infrastructure/environments/swarm-to-k8s.ts
@@ -89,7 +89,7 @@ import { createEnvironmentSecret, createEnvironmentVariable, getRepositoryId } f
             // FIXME: In general that should be environment_type,
             // Hardcode like this blocks us from being generic:
             // https://github.com/opencrvs/opencrvs-core/issues/11171
-            is_qa_env: environment !== 'production' ? "true" : "false",
+            two_fa_enabled: environment !== 'production' ? true : false,
             backup_enabled: environment === 'production' ? "true" : "false",
             restore_enabled: environment === 'staging' ? "true" : "false",
             restore_environment_name: environment === 'staging' ? "production" : "",

--- a/infrastructure/environments/swarm-to-k8s.ts
+++ b/infrastructure/environments/swarm-to-k8s.ts
@@ -89,7 +89,7 @@ import { createEnvironmentSecret, createEnvironmentVariable, getRepositoryId } f
             // FIXME: In general that should be environment_type,
             // Hardcode like this blocks us from being generic:
             // https://github.com/opencrvs/opencrvs-core/issues/11171
-            two_fa_enabled: environment !== 'production' ? true : false,
+            two_fa_enabled: environment !== 'production' ? false : true,
             backup_enabled: environment === 'production' ? "true" : "false",
             restore_enabled: environment === 'staging' ? "true" : "false",
             restore_environment_name: environment === 'staging' ? "production" : "",

--- a/infrastructure/environments/swarm-to-k8s.ts
+++ b/infrastructure/environments/swarm-to-k8s.ts
@@ -89,7 +89,6 @@ import { createEnvironmentSecret, createEnvironmentVariable, getRepositoryId } f
             // FIXME: In general that should be environment_type,
             // Hardcode like this blocks us from being generic:
             // https://github.com/opencrvs/opencrvs-core/issues/11171
-            is_qa_env: environment !== 'production' ? "true" : "false",
             backup_enabled: environment === 'production' ? "true" : "false",
             restore_enabled: environment === 'staging' ? "true" : "false",
             restore_environment_name: environment === 'staging' ? "production" : "",

--- a/infrastructure/environments/templates/charts-values/opencrvs-services/values.yaml
+++ b/infrastructure/environments/templates/charts-values/opencrvs-services/values.yaml
@@ -21,7 +21,6 @@ hpa:
 
 env:
   APN_SERVICE_URL: "http://apm-server.opencrvs-deps-{{env}}.svc.cluster.local:8200"
-  QA_ENV: {{is_qa_env}}
   MINIO_BUCKET: ocrvs
 
 influxdb:

--- a/infrastructure/environments/templates/charts-values/opencrvs-services/values.yaml
+++ b/infrastructure/environments/templates/charts-values/opencrvs-services/values.yaml
@@ -21,8 +21,11 @@ hpa:
 
 env:
   APN_SERVICE_URL: "http://apm-server.opencrvs-deps-{{env}}.svc.cluster.local:8200"
-  TWO_FA_ENABLED: {{two_fa_enabled}}
   MINIO_BUCKET: ocrvs
+
+events:
+  env:
+    TWO_FA_ENABLED: {{two_fa_enabled}}
 
 influxdb:
   host: influxdb-0.influxdb.opencrvs-deps-{{env}}.svc.cluster.local

--- a/infrastructure/environments/templates/charts-values/opencrvs-services/values.yaml
+++ b/infrastructure/environments/templates/charts-values/opencrvs-services/values.yaml
@@ -21,7 +21,7 @@ hpa:
 
 env:
   APN_SERVICE_URL: "http://apm-server.opencrvs-deps-{{env}}.svc.cluster.local:8200"
-  QA_ENV: {{is_qa_env}}
+  TWO_FA_ENABLED: {{two_fa_enabled}}
   MINIO_BUCKET: ocrvs
 
 influxdb:


### PR DESCRIPTION
## Summary

- `QA_ENV` is no longer read by any OpenCRVS service following the migration from `QA_ENV` to `TWO_FA_ENABLED` in core services (`auth`, `gateway`, `events`)
- The `opencrvs-helm-charts` default `values.yaml` has already had `QA_ENV: true` removed in a companion PR
- This PR removes the three remaining dead-code references in the infrastructure provisioning tooling:
  - `templates/charts-values/opencrvs-services/values.yaml` — removes `QA_ENV: {{is_qa_env}}` from the generated env block
  - `swarm-to-k8s.ts` — removes the `is_qa_env` template variable
  - `setup-environment.ts` — removes the `is_qa_env` template variable

replacement added — TWO_FA_ENABLED. 