### PR TITLE
fix: Skip configuration files override on environment:init (upgrade) flow

### DIFF
--- a/infrastructure/environments/templates.ts
+++ b/infrastructure/environments/templates.ts
@@ -77,31 +77,42 @@ export function extractWorkerNodes(data: any): string[] {
 export function copyChartsValues(env: string, values: Record<string, string | boolean>) {
   const srcDir = path.resolve(__dirname, "templates", "charts-values");
   const destDir = path.resolve(__dirname, "..", "..", "environments", env);
+
   fs.mkdirSync(destDir, { recursive: true });
-  values['lets_encrypt'] = values['traefik_mode'] === "lets_encrypt" ? true : false
-  values['static_ssl'] = values['traefik_mode'] === "static_ssl" ? true : false
+
+  values['lets_encrypt'] = values['traefik_mode'] === "lets_encrypt";
+  values['static_ssl'] = values['traefik_mode'] === "static_ssl";
+
   function copyRecursive(src: string, dest: string) {
     const stat = fs.statSync(src);
 
     if (stat.isDirectory()) {
       fs.mkdirSync(dest, { recursive: true });
+
       for (const item of fs.readdirSync(src)) {
         copyRecursive(path.join(src, item), path.join(dest, item));
       }
     } else {
-      // read file
       const content = fs.readFileSync(src, "utf8");
 
-      // replace placeholders
       const template = Handlebars.compile(content);
       const updated = template(values);
-      // write updated file
+      
+      const isOverridesFile = dest.endsWith("override.yaml");
+      // Skip overwrite for existing overrides.yaml
+      if (isOverridesFile && fs.existsSync(dest)) {
+        log(`  ↷ Skipped existing overrides file: ${dest}`);
+        return;
+      }
+
       fs.writeFileSync(dest, updated, "utf8");
       log(`  ✓ Created: ${dest}`);
     }
   }
+
   log(`\n📋 Copying charts-values templates to ${destDir}:`);
   copyRecursive(srcDir, destDir);
+
   success(`✅ Completed copying charts-values.\n`);
 }
 


### PR DESCRIPTION
# Description

Related issue: [[opencrvs/opencrvs-core issue #12495](https://github.com/opencrvs/opencrvs-core/issues/12495?)

The `yarn environment:init` script generates the following Helm chart configuration files for each environment:

```text
├── dependencies
│   ├── values.override.yaml
│   └── values.yaml
├── opencrvs-services
│   ├── values.override.yaml
│   └── values.yaml
└── traefik
    ├── values.override.yaml
    └── values.yaml
```

* `values.yaml` files are managed and regenerated by `yarn environment:init`
* `values.override.yaml` files are intended for operator-managed customisation (DevOps, SysAdmins)

This PR changes the behaviour of `yarn environment:init` to preserve existing `values.override.yaml` files instead of overwriting them, delegating full control of these files to operators.

# Testing

Steps
1. Create test environment: run `yarn environment:init`
2. Modify values.override.yaml file
3. Re-run `yarn environment:init`

## Create test environment

Run: `yarn environment:init`

<img width="628" height="202" alt="image" src="https://github.com/user-attachments/assets/67d65736-3620-4377-8827-1264ecf39ed5" />

## Modify values.override.yaml file

<img width="951" height="230" alt="image" src="https://github.com/user-attachments/assets/d151a128-ab00-4597-a06c-f8f5934a0595" />

## Re-run `yarn environment:init`

<img width="803" height="268" alt="image" src="https://github.com/user-attachments/assets/55e668c2-c986-421b-8d35-29b3e7abd5aa" />
