### PR TITLE
fix: Don't ask "Do you want to enable disk encryption?" for configured environment

### DIFF
--- a/infrastructure/environments/setup-environment.ts
+++ b/infrastructure/environments/setup-environment.ts
@@ -270,50 +270,7 @@ ALL_QUESTIONS.push(
 )
 
 ; (async () => {
-
-  const environment = await selectWithCustom(
-        {
-        message: 'Choose a name and purpose for the environment?',
-        choices: [
-          { name: 'Development', value: 'development' },
-          { name: 'Quality assurance (no PII data)', value: 'qa' },
-          {
-            name: 'Staging (hosts PII data, no backups)',
-            value: 'staging'
-          },
-          {
-            name: 'Production (hosts PII data, requires frequent backups)',
-            value: 'production'
-          },
-        ]
-      }
-    )
-    let environment_type = 'non-production'
-    if (['development', 'qa'].includes(environment)) {
-        environment_type = 'non-production'
-    } else if (['staging', 'production'].includes(environment)) {
-        environment_type = 'production'
-    } else {
-        environment_type = await select(
-          {
-            message: 'Purpose for the environment?',
-            choices: [
-            { name: 'Development/Quality assurance/Testing (no PII data)', value: 'non-production' },
-            { name: 'Staging/Production (hosts PII data, requires frequent backups)', value: 'production' },
-            ],
-          }
-        )
-    }
-    if (!environment) {
-        process.exit(1)
-      }
-    // Read users .env file based on the environment name they gave above, e.g. .env.production
-    dotenv.config({
-      path: `${process.cwd()}/.env.${environment}`
-    })
-
     log('\n', kleur.bold().underline('Github'), '\n')
-
     const { githubOrganisation, githubRepository } = await prompts(
       githubQuestions.map(questionToPrompt),
       {
@@ -332,8 +289,65 @@ ALL_QUESTIONS.push(
     const octokit = new Octokit({
       auth: githubToken
     })
-
+    log(kleur.green('\nSuccessfully logged in to Github\n'))
     let existingEnvironments = await getRepositoryEnvironments(octokit, githubOrganisation, githubRepository);
+
+    let defaultChoices = [
+            { name: 'Development', value: 'development' },
+            { name: 'Quality assurance (no PII data)', value: 'qa' },
+            {
+              name: 'Staging (hosts PII data, no backups)',
+              value: 'staging'
+            },
+            {
+              name: 'Production (hosts PII data, requires frequent backups)',
+              value: 'production'
+            },
+          ]
+    // Add only environments that are not already present
+    const choices = [
+      ...defaultChoices,
+      ...existingEnvironments
+        .filter(
+          (env) => !defaultChoices.some((choice) => choice.value === env)
+        )
+        .map((env) => ({
+          name: env,
+          value: env
+        }))
+    ];
+    const environment = await selectWithCustom(
+          {
+          message: 'Choose a name and purpose for the environment?',
+          choices: choices
+        }
+    )
+    let environment_type = 'non-production'
+    if (['development', 'qa'].includes(environment)) {
+        environment_type = 'non-production'
+    } else if (['staging', 'production'].includes(environment)) {
+        environment_type = 'production'
+    } else {
+        environment_type = await select(
+          {
+            message: 'Purpose for the environment?',
+            choices: [
+            { name: 'Development/Quality assurance/Testing (no PII data)', value: 'non-production' },
+            { name: 'Staging/Production (hosts PII data, requires frequent backups)', value: 'production' },
+            ],
+          }
+        )
+    }
+    const environment_exists = existingEnvironments
+      .map((e) => e.trim())
+      .includes(environment);
+    if (!environment) {
+        process.exit(1)
+      }
+    // Read users .env file based on the environment name they gave above, e.g. .env.production
+    dotenv.config({
+      path: `${process.cwd()}/.env.${environment}`
+    })
 
     await createEnvironment(
       octokit,
@@ -392,8 +406,6 @@ ALL_QUESTIONS.push(
         existingEnvironmentSecrets.length,
         'secrets'
       )
-    } else {
-      log(kleur.green('\nSuccessfully logged in to Github\n'))
     }
     if (environment_type === 'production') {
       log('\n', kleur.yellow().bold(
@@ -447,17 +459,16 @@ ALL_QUESTIONS.push(
       ssl_answers = await askQuestionWithEditor(staticSSLCertQuestions, existingEnvironmentSecrets)
     }
     
-    log('\n', kleur.bold().underline('Storage'))
+    log('\n', kleur.bold().underline('Storage'), '\n')
 
-    let enableEncryption = true
+    let enableEncryption = false
     const encryption_key_defined = findExistingValue(
       'ENCRYPTION_KEY',
       'SECRET',
       'ENVIRONMENT',
       existingValues
     )
-
-    if (!encryption_key_defined) {
+    if (!encryption_key_defined && !environment_exists) {
       const answers_enable_encryption = await prompts(
         [
           {
@@ -471,7 +482,7 @@ ALL_QUESTIONS.push(
       )
       enableEncryption = answers_enable_encryption.enableEncryption
     }
-    if (enableEncryption && !encryption_key_defined) {
+    if (enableEncryption && !encryption_key_defined && !environment_exists) {
       log(kleur.bold().green('✔'), kleur.bold().yellow(' Disk encryption is enabled'))
       await promptAndStoreAnswer(environment, diskQuestions, existingValues)
     } else {
@@ -481,7 +492,11 @@ ALL_QUESTIONS.push(
         'ENVIRONMENT',
         existingValues
       )
-      log(kleur.bold().green('✔'), kleur.bold().yellow('Variable DISK_SPACE is read-only variable:'), DISK_SPACE?.value)
+      if (!DISK_SPACE) {
+        log(kleur.bold().green('✔'), kleur.bold().grey('All available disk space at /data will be used'))
+      } else {
+        log(kleur.bold().green('✔'), kleur.bold().yellow('Variable DISK_SPACE is read-only variable:'), DISK_SPACE?.value)
+      }
     }
 
     // Backup and restore configuration


### PR DESCRIPTION
# Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/12500

Applied fixes:

## Order for the questions changed
- From:
   - Choose a name and purpose for the environment?
   - What is the name of your Github organisation?
   - What is your Github infrastructure repository?
   - GH_TOKEN: What is your Github token?
- To:
   - Choose a name and purpose for the environment?
   - What is the name of your Github organisation?
   - What is your Github infrastructure repository?
   - GH_TOKEN: What is your Github token?

The change allows to add all existing environments to the environment name choice list.

## Don't ask question about disk encryption for existing environment

If environment was already setup we need to skip encryption question, otherwise there is a chance to break citizens data. Disk size question should be also skipped.

# Testing

## Questions order change

<img width="704" height="291" alt="image" src="https://github.com/user-attachments/assets/20d34edc-ffda-40bf-92ae-ba3f23def885" />

## New environment: Storage configuration with encryption

Goal: Create new environment `development` and configure encryption partition (size 200g)

<img width="1073" height="163" alt="image" src="https://github.com/user-attachments/assets/7b0be332-ef42-454c-997c-d73ed378ebb7" />

## Existing environment: Storage configuration with encryption

Goal: Re-run script during environment upgrade from vX.Y.Z to vX.B.C. In more real world between v1.9.14 and v2.0.0. We need to skip Storage question to avoid end-user confusion.

<img width="794" height="79" alt="image" src="https://github.com/user-attachments/assets/68bac2f8-5be9-46ba-a790-61fb71ca7ba8" />

## New environment: Storage configuration without encryption

<img width="597" height="72" alt="image" src="https://github.com/user-attachments/assets/0838fe4b-4a9e-4bde-95d4-c00033d3af4b" />


## Existing environment: Encryption was disabled at creation time

Goal: Re-run script during environment upgrade from vX.Y.Z to vX.B.C. In more real world between v1.9.14 and v2.0.0. We need to skip Storage question to avoid end-user confusion.

<img width="574" height="82" alt="image" src="https://github.com/user-attachments/assets/eea7667b-fcab-4e86-9859-77576b6f0e21" />
