### PR TITLE
chore: Kubernetes upgrade from 1.34 to 1.35

### DIFF
--- a/infrastructure/server-setup/group_vars/all.yml
+++ b/infrastructure/server-setup/group_vars/all.yml
@@ -30,7 +30,7 @@ min_free_disk_size: "30g"
 # - kubeadm
 # - kubelet
 # - kubectl
-kubernetes_version: "v1.34"
+kubernetes_version: "v1.35"
 
 # Kubernetes Eviction Policy Configuration
 #
@@ -56,15 +56,15 @@ eviction_soft_imagefs: "20Gi"         # Minimum free space for container images 
 
 
 # Container Network Interface plugin: Calico version
-calico_version: "v3.26.1"
-# CNI configuration
+calico_version: "v3.32.0"
+# CNI configuration (read-only after installation)
 pod_network_cidr: "192.168.0.0/16"
 
 # Helm version
-helm_version: "v3.19.2"
+helm_version: "v4.1.1"
 
 # Certificate manager chart version
-cert_manager_version: "v1.19.1"
+cert_manager_version: "v1.20.2"
 
 # Action runner controller chart version
 arc_chart_version: "0.23.7"

--- a/infrastructure/server-setup/tasks/k8s/cert-manager.yml
+++ b/infrastructure/server-setup/tasks/k8s/cert-manager.yml
@@ -4,7 +4,7 @@
     chart_ref: cert-manager
     chart_repo_url: https://charts.jetstack.io
     release_namespace: cert-manager
-    chart_version: {{ cert_manager_version }}
+    chart_version: "{{ cert_manager_version }}"
     create_namespace: true
     values:
       crds:

--- a/infrastructure/server-setup/tasks/k8s/cert-manager.yml
+++ b/infrastructure/server-setup/tasks/k8s/cert-manager.yml
@@ -4,7 +4,7 @@
     chart_ref: cert-manager
     chart_repo_url: https://charts.jetstack.io
     release_namespace: cert-manager
-    chart_version: v1.19.1
+    chart_version: {{ cert_manager_version }}
     create_namespace: true
     values:
       crds:

--- a/infrastructure/server-setup/tasks/k8s/install-network-plugin.yml
+++ b/infrastructure/server-setup/tasks/k8s/install-network-plugin.yml
@@ -1,12 +1,19 @@
 ---
+
+# Ref: https://docs.tigera.io/calico/latest/getting-started/kubernetes/quickstart
+- name: Create Calico custom resource definitions
+  shell: |
+    curl  --retry-all-errors --retry 5 -O https://raw.githubusercontent.com/projectcalico/calico/{{ calico_version }}/manifests/v1_crd_projectcalico_org.yaml
+    kubectl apply --server-side=true --force-conflicts -f v1_crd_projectcalico_org.yaml
+  environment:
+    KUBECONFIG: /home/provision/.kube/config
+
 - name: Install Tigera Operator
   shell: |
     curl  --retry-all-errors --retry 5 -O https://raw.githubusercontent.com/projectcalico/calico/{{ calico_version }}/manifests/tigera-operator.yaml
-    kubectl create -f tigera-operator.yaml
+    kubectl apply --server-side=true --force-conflicts -f tigera-operator.yaml
   environment:
     KUBECONFIG: /home/provision/.kube/config
-  register: tigera_result
-  failed_when: tigera_result.rc != 0 and "already exists" not in tigera_result.stderr
 
 - name: Create Calico custom resources configuration
   copy:

--- a/infrastructure/server-setup/tasks/k8s/self-hosted-runner.yml
+++ b/infrastructure/server-setup/tasks/k8s/self-hosted-runner.yml
@@ -45,7 +45,7 @@
         apiGroup: rbac.authorization.k8s.io
 
 - name: Deploy opencrvs-infra-runner
-  retries: 5
+  retries: 10
   delay: 60
   kubernetes.core.k8s:
     state: present

--- a/infrastructure/server-setup/tasks/k8s/upgrade-k8s-master.yml
+++ b/infrastructure/server-setup/tasks/k8s/upgrade-k8s-master.yml
@@ -28,10 +28,57 @@
   become: yes
   command: kubeadm config images pull
   when: upgrade_needed
+
+# Kubernetes v1.35+ kubelet no longer accepts --pod-infra-container-image.
+# If this stale flag remains in /var/lib/kubelet/kubeadm-flags.env after upgrade,
+# kubelet fails to start with:
+#   failed to parse kubelet flag: unknown flag: --pod-infra-container-image
+#
+# The sandbox/pause image should be configured through the container runtime
+# instead, e.g. containerd's sandbox_image.
+#
+# Related kubeadm issue:
+# https://github.com/kubernetes/kubeadm/issues/3281
+- name: Check kubeadm kubelet flags file
+  become: yes
+  ansible.builtin.stat:
+    path: /var/lib/kubelet/kubeadm-flags.env
+  register: kubeadm_flags_file
+
+- name: Remove deprecated kubelet pod-infra-container-image flag
+  become: yes
+  ansible.builtin.replace:
+    path: /var/lib/kubelet/kubeadm-flags.env
+    regexp: '\s*--pod-infra-container-image=[^ "]*'
+    replace: ''
+  when: 
+    - kubeadm_flags_file.stat.exists
+    - upgrade_needed
+  register: kubeadm_flags_cleanup
+
+- name: Restart kubelet after removing deprecated flag
+  become: yes
+  ansible.builtin.systemd:
+    name: kubelet
+    daemon_reload: yes
+    state: restarted
+  when:
+    - kubeadm_flags_file.stat.exists
+    - kubeadm_flags_cleanup.changed
+    - upgrade_needed
+
+- name: Plan kubeadm upgrade
+  when: upgrade_needed
+  become: yes
+  ansible.builtin.shell: kubeadm upgrade plan
+  retries: 3
+  delay: 20
+  when: upgrade_needed
+
 - name: Apply kubeadm upgrade to kubelet version
   when: upgrade_needed
   become: yes
-  ansible.builtin.shell: kubeadm upgrade apply {{ kubelet_version }} -y
+  ansible.builtin.shell: kubeadm upgrade apply {{ kubelet_version }} -y --v=5
 
 - name: Restart kubelet
   become: yes

--- a/infrastructure/server-setup/tasks/k8s/upgrade-k8s-master.yml
+++ b/infrastructure/server-setup/tasks/k8s/upgrade-k8s-master.yml
@@ -73,7 +73,6 @@
   ansible.builtin.shell: kubeadm upgrade plan
   retries: 3
   delay: 20
-  when: upgrade_needed
 
 - name: Apply kubeadm upgrade to kubelet version
   when: upgrade_needed

--- a/infrastructure/server-setup/tasks/k8s/upgrade-k8s-workers.yml
+++ b/infrastructure/server-setup/tasks/k8s/upgrade-k8s-workers.yml
@@ -1,3 +1,27 @@
+# Kubernetes v1.35+ kubelet no longer accepts --pod-infra-container-image.
+# If this stale flag remains in /var/lib/kubelet/kubeadm-flags.env after upgrade,
+# kubelet fails to start with:
+#   failed to parse kubelet flag: unknown flag: --pod-infra-container-image
+#
+# The sandbox/pause image should be configured through the container runtime
+# instead, e.g. containerd's sandbox_image.
+#
+# Related kubeadm issue:
+# https://github.com/kubernetes/kubeadm/issues/3281
+- name: Check kubeadm kubelet flags file
+  become: yes
+  ansible.builtin.stat:
+    path: /var/lib/kubelet/kubeadm-flags.env
+  register: kubeadm_flags_file
+
+- name: Remove deprecated kubelet pod-infra-container-image flag
+  become: yes
+  ansible.builtin.replace:
+    path: /var/lib/kubelet/kubeadm-flags.env
+    regexp: '\s*--pod-infra-container-image=[^ "]*'
+    replace: ''
+  when: kubeadm_flags_file.stat.exists
+
 # NOTE: Nodes are not cordoned and workloads keep running while kubelet restart
 #       Application may become not available if upgrade fails.
 - name: Restart kubelet


### PR DESCRIPTION
# Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/12614

Reference PR for infrastructure testing: https://github.com/opencrvs/opencrvs-farajaland-infrastructure/pull/9

Components included into upgrade:
| Component | Source version | Target version |
|---|---|---:|
| Kubernetes components | v1.34.7 | v1.35 |
| Container Network Interface plugin | v3.26.1 | v3.32.0 |
| Helm | v3.19.2  | v4.1.1 |
| Actions Runner Controller chart | - | 0.23.7 |
| cert-manager chart | v1.19.1 | v1.20.2 |


# Testing

## Status before upgrade
Infrastructure:
<img width="1489" height="267" alt="image" src="https://github.com/user-attachments/assets/1827b951-1293-46a1-a468-63574372004b" />

Initial kubernetes version (kubectl, kubeadm, kubelet): 1.34.7
<img width="1422" height="93" alt="image" src="https://github.com/user-attachments/assets/fa314891-6406-4c16-971e-329c649c6cbf" />

Calico:
<img width="1029" height="288" alt="image" src="https://github.com/user-attachments/assets/4e4e9149-e9c6-49b3-ada3-eab5e86cde9b" />


Cert-manager:
<img width="1062" height="39" alt="image" src="https://github.com/user-attachments/assets/9a902fe3-c5a9-4278-92ee-a1e37d3711c8" />

## Workflow execution

Link: https://github.com/opencrvs/opencrvs-farajaland-infrastructure/actions/runs/25845751599/job/75940670321
Identified new version for upgrade:
<img width="1417" height="127" alt="image" src="https://github.com/user-attachments/assets/c7d8c806-9944-4a9c-b91f-f785b03d36e5" />
Kubelet is not available right after restart, we added retries:
<img width="884" height="349" alt="image" src="https://github.com/user-attachments/assets/b04a3800-c7ac-41a4-b520-a6f4c015caf1" />


## Post upgrade validation:
Infrastructure:
<img width="1389" height="74" alt="image" src="https://github.com/user-attachments/assets/313d8791-e4f8-40f0-bbe0-6fa998b8ca3b" />

Calico:
<img width="778" height="126" alt="image" src="https://github.com/user-attachments/assets/bf2cc49d-5175-4bb0-8ea6-e781c2e1d6db" />
Cert-manager:
<img width="778" height="79" alt="image" src="https://github.com/user-attachments/assets/852a6a98-bb59-4783-83c9-27190d335df1" />


## Re-run after provision

Workflow: https://github.com/opencrvs/opencrvs-farajaland-infrastructure/actions/runs/25800906350/job/75790440249