### PR TITLE
fix: pin kubernetes packages from pkgs.k8s.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 2.0.0 Release Candidate
+
+### Bug fixes
+
+- Azure VMs may install Kubernetes packages from Microsoft APT repository instead of pkgs.k8s.io [#12613](https://github.com/opencrvs/opencrvs-core/issues/12613)

--- a/infrastructure/server-setup/tasks/k8s/install-kubernetes.yml
+++ b/infrastructure/server-setup/tasks/k8s/install-kubernetes.yml
@@ -21,6 +21,19 @@
     filename: kubernetes
     state: present
 
+- name: Prefer Kubernetes packages from pkgs.k8s.io
+  ansible.builtin.copy:
+    dest: /etc/apt/preferences.d/kubernetes-pkgs-k8s
+    mode: "0644"
+    content: |
+      Package: kubelet kubeadm kubectl
+      Pin: origin pkgs.k8s.io
+      Pin-Priority: 1001
+
+      Package: kubelet kubeadm kubectl
+      Pin: origin packages.microsoft.com
+      Pin-Priority: -1
+
 - name: Install specific Kubernetes version
   become: yes
   ansible.builtin.apt:


### PR DESCRIPTION
# Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/12613

Kubernetes packages can be installed from the wrong APT repository on Azure VMs.

Azure Ubuntu images may include Microsoft package repositories that also provide Kubernetes packages. During OpenCRVS infrastructure provisioning or upgrade, apt may select kubelet, kubeadm, or kubectl from the Microsoft repository instead of the official Kubernetes repository.

Check full description inside issue [#12613](https://github.com/opencrvs/opencrvs-core/issues/12613)


# Testing

Workflow: https://github.com/opencrvs/opencrvs-farajaland-infrastructure/actions/runs/25860662593/job/75989474396

<img width="719" height="84" alt="image" src="https://github.com/user-attachments/assets/3e4d3f37-9584-4f6f-a788-ef64a72280e5" />
