### PR TITLE
fix: Runner directory must belong to provision user

### DIFF
--- a/scripts/bootstrap/node-runner.sh
+++ b/scripts/bootstrap/node-runner.sh
@@ -102,7 +102,7 @@ if [[ ! -f "runner.tar.gz" ]]; then
   fi
 
   echo "[+] Download URL: $RUNNER_LATEST_URL into folder $(pwd)"
-  if ! curl -fL "$RUNNER_LATEST_URL" -o runner.tar.gz; then
+  if ! sudo -u $RUNAS_USER curl -fL "$RUNNER_LATEST_URL" -o runner.tar.gz; then
     echo "❌ Failed to download runner archive."
     exit 1
   fi
@@ -111,9 +111,9 @@ else
 fi
 
 echo "[+] Extracting runner..."
-tar xzf runner.tar.gz
+sudo -u $RUNAS_USER tar xzf runner.tar.gz
 echo "[+] Setting permissions... `pwd`"
-chown -R $RUNAS_USER:$RUNAS_GROUP .
+sudo chown -R $RUNAS_USER:$RUNAS_GROUP .
 # --- GET REGISTRATION TOKEN ---
 echo "[+] Requesting registration token..."
 REG_TOKEN=$(curl -s -X POST \
@@ -133,7 +133,7 @@ sudo -u $RUNAS_USER ./config.sh \
 # --- SETUP SYSTEMD SERVICE ---
 echo "[+] Installing systemd service..."
 
-sudo ./svc.sh install
+sudo ./svc.sh install provision
 
 # Fix service to run as specific user/group
 SERVICE_FILE_PATH=$(ls /etc/systemd/system/actions.runner.*.service 2>/dev/null | head -n1)


### PR DESCRIPTION
# Description


<img width="783" height="293" alt="image" src="https://github.com/user-attachments/assets/daca7fe2-674a-4cd5-bbfd-d577f461c532" />

```
curl: (23) Failure writing output to destination
❌ Failed to download runner archive.
```

# Testing

```
[+] Updating systemd unit to run as provision:provision...

/etc/systemd/system/actions.runner.opencrvs-infrastructure.tmp-one-time-test-runner.service
● actions.runner.opencrvs-infrastructure.tmp-one-time-test-runner.service - GitHub Actions Runner (opencrvs-infrastructure.tmp-one-time-test-runner)
     Loaded: loaded (/etc/systemd/system/actions.runner.opencrvs-infrastructure.tmp-one-time-test-runner.service; enabled; preset: enabled)
     Active: active (running) since Thu 2026-05-14 15:00:07 UTC; 7ms ago
   Main PID: 4616 (runsvc.sh)
      Tasks: 2 (limit: 4531)
     Memory: 644.0K (peak: 820.0K)
        CPU: 5ms
     CGroup: /system.slice/actions.runner.opencrvs-infrastructure.tmp-one-time-test-runner.service
             └─4616 /bin/bash /opt/github-runner/runsvc.sh

May 14 15:00:07 tmp-one-time-test systemd[1]: Started actions.runner.opencrvs-infrastructure.tmp-one-tim…nner).
Hint: Some lines were ellipsized, use -l to show in full.
✅ Runner 'tmp-one-time-test-runner' is installed and started!


⚠️ ⚠️ ⚠️ ⚠️ ⚠️ Store the following public key for later usage ⚠️ ⚠️ ⚠️ ⚠️ ⚠️
⚙️  provision SSH key pair public key (add on worker nodes if needed):

ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKICupQfHA0R94tcpWTboMn+bzIr6EVPF1F9wNO+IT5/ provision@tmp-one-time-test

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ✅ Node bootstrap complete for tmp-one-time-test.
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```