### PR TITLE
fix: Git rid of call to countryconfig from elastalert service

### DIFF
--- a/.github/TEMPLATES/secret-mapping-opencrvs-deps.yml
+++ b/.github/TEMPLATES/secret-mapping-opencrvs-deps.yml
@@ -66,3 +66,16 @@ restore-encryption-secret:
   type: Opaque
   data:
   - RESTORE_ENCRYPTION_PASSPHRASE: backup_encryption_key
+
+
+# SMTP configuration for ElastAlert email notifications
+smtp-config:
+  type: Opaque
+  data:
+  - SENDER_EMAIL_ADDRESS
+  - SMTP_HOST
+  - SMTP_PASSWORD
+  - SMTP_PORT
+  - SMTP_SECURE
+  - SMTP_USERNAME
+  - ALERT_EMAIL

--- a/infrastructure/environments/templates/charts-values/dependencies/values.yaml
+++ b/infrastructure/environments/templates/charts-values/dependencies/values.yaml
@@ -54,7 +54,16 @@ monitoring:
 
 elastalert:
   env:
-    HTTP_POST2_ALERT_URL: http://countryconfig.opencrvs-{{env}}.svc.cluster.local:3040/email
+    NOTIFICATION_TYPE: email
+  secrets:
+    smtp-config:
+      - ALERT_EMAIL
+      - SENDER_EMAIL_ADDRESS
+      - SMTP_HOST
+      - SMTP_PASSWORD
+      - SMTP_PORT
+      - SMTP_SECURE
+      - SMTP_USERNAME
 
 # Backup configuration
 backup:


### PR DESCRIPTION
# Description

Related PR: https://github.com/opencrvs/opencrvs-core/pull/12791

Issue: https://github.com/opencrvs/opencrvs-core/issues/10608

Elastalert is deployed as part of monitoring solution for OpenCRVS, but makes a call to countryconfig service.
If countryconfig is not available for some reason then alerting will not work as well.

Goal of this PR is to replace HTTP POST call to countryconfig with direct SMTP call to email server.

```mermaid
flowchart LR
    A[ElastAlert] -->|Current: HTTP POST| B[countryconfig:3040/email]
    B -->|Current: SMTP| C[email-server:587]

    A -.->|New: direct SMTP| C

```

See testing results at https://github.com/opencrvs/opencrvs-core/pull/12791