### PR TITLE
fix: Refactor Kubernetes & Runtime Questions

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -66,9 +66,7 @@ jobs:
         env:
           encrypted_disk_size: ${{ vars.DISK_SPACE }}
           disk_encryption_key: ${{ secrets.ENCRYPTION_KEY }}
-          k8s_runner_token: ${{ secrets.GH_TOKEN }}
           repository: ${{ github.repository }}
-          k8s_cluster_env: ${{ inputs.environment }}
           smtp_host: ${{ secrets.SMTP_HOST }}
           smtp_port: ${{ secrets.SMTP_PORT }}
           smtp_user: ${{ secrets.SMTP_USERNAME }}
@@ -77,9 +75,11 @@ jobs:
           smtp_password: ${{ secrets.SMTP_PASSWORD }}
           alert_email: ${{ secrets.ALERT_EMAIL }}
           backup_host_public_key: ${{ secrets.BACKUP_HOST_PUBLIC_KEY }}
-          kubernetes_api_allowed_cidrs: ${{ vars.KUBE_API_ALLOWED_CIDRS }}
-          cluster_node_cidr: ${{ vars.KUBE_CLUSTER_NODE_CIDR }}
-          self_hosted_runner_additional_labels: ${{ vars.SELF_HOSTED_RUNNER_ADDITIONAL_LABELS }}
+          kube_cluster_env: ${{ inputs.environment }}
+          kube_api_allowed_cidrs: ${{ vars.KUBE_API_ALLOWED_CIDRS }}
+          kube_cluster_node_cidr: ${{ vars.KUBE_CLUSTER_NODE_CIDR }}
+          kube_runner_token: ${{ secrets.GH_TOKEN }}
+          self_hosted_runner_additional_labels: ${{ vars.KUBE_SELF_HOSTED_RUNNER_ADDITIONAL_LABELS }}
       - name: checkout repository
         uses: actions/checkout@v6
       - name: Run Ansible Playbook

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -77,6 +77,9 @@ jobs:
           smtp_password: ${{ secrets.SMTP_PASSWORD }}
           alert_email: ${{ secrets.ALERT_EMAIL }}
           backup_host_public_key: ${{ secrets.BACKUP_HOST_PUBLIC_KEY }}
+          kubernetes_api_allowed_cidrs: ${{ vars.KUBE_API_ALLOWED_CIDRS }}
+          cluster_node_cidr: ${{ vars.KUBE_CLUSTER_NODE_CIDR }}
+          self_hosted_runner_additional_labels: ${{ vars.SELF_HOSTED_RUNNER_ADDITIONAL_LABELS }}
       - name: checkout repository
         uses: actions/checkout@v6
       - name: Run Ansible Playbook

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -79,7 +79,7 @@ jobs:
           kube_api_allowed_cidrs: ${{ vars.KUBE_API_ALLOWED_CIDRS }}
           kube_cluster_node_cidr: ${{ vars.KUBE_CLUSTER_NODE_CIDR }}
           kube_runner_token: ${{ secrets.GH_TOKEN }}
-          self_hosted_runner_additional_labels: ${{ vars.KUBE_SELF_HOSTED_RUNNER_ADDITIONAL_LABELS }}
+          kube_self_hosted_runner_additional_labels: ${{ vars.KUBE_SELF_HOSTED_RUNNER_ADDITIONAL_LABELS }}
       - name: checkout repository
         uses: actions/checkout@v6
       - name: Run Ansible Playbook

--- a/infrastructure/environments/questions.ts
+++ b/infrastructure/environments/questions.ts
@@ -6,6 +6,37 @@ import { getRepoInfo } from './git'
 const notEmpty = (value: string | number) =>
   value.toString().trim().length > 0 ? true : 'Please enter a value'
 
+function validateCIDR(input: string): true | string {
+  if (!input.trim()) {
+    return true
+  }
+
+  const cidrRegex =
+    /^((25[0-5]|(2[0-4]|1\d|[1-9]?\d)\d?)\.){3}(25[0-5]|(2[0-4]|1\d|[1-9]?\d)\d?)\/([0-9]|[12][0-9]|3[0-2])$/
+
+  return cidrRegex.test(input.trim())
+    ? true
+    : 'Please enter a valid CIDR (e.g. 10.0.0.0/24)'
+}
+
+function validateCIDRs(input: string): true | string {
+  if (!input.trim()) {
+    return true
+  }
+
+  const cidrs = input.split(',').map((v) => v.trim())
+
+  for (const cidr of cidrs) {
+    const result = validateCIDR(cidr)
+
+    if (result !== true) {
+      return `Invalid CIDR: ${cidr}`
+    }
+  }
+
+  return true
+}
+
 
 export const dockerhubQuestions = [
   {
@@ -154,7 +185,7 @@ export const infrastructureQuestions = [
     message:
       `Allowed CIDRs for Kubernetes API access (default: unrestricted)`,
     valueType: 'VARIABLE' as const,
-    // validate: notEmpty,
+    validate: validateCIDRs,
     valueLabel: 'KUBE_API_ALLOWED_CIDRS',
     initial: process.env.KUBE_API_ALLOWED_CIDRS || "0.0.0.0/0",
     scope: 'ENVIRONMENT' as const,
@@ -176,7 +207,7 @@ export const infrastructureQuestions = [
     message:
       `Cluster network CIDR (default: no restrictions)`,
     valueType: 'VARIABLE' as const,
-    // validate: notEmpty,
+    validate: validateCIDR,
     valueLabel: 'KUBE_CLUSTER_NODE_CIDR',
     initial: process.env.KUBE_CLUSTER_NODE_CIDR || "0.0.0.0/0",
     scope: 'ENVIRONMENT' as const,

--- a/infrastructure/environments/questions.ts
+++ b/infrastructure/environments/questions.ts
@@ -160,14 +160,14 @@ export const infrastructureQuestions = [
     scope: 'ENVIRONMENT' as const,
   },
   {
-    name: 'workerNodes',
+    name: 'kubeWorkerNodes',
     type: 'text' as const,
     message:
-      `Kubernetes worker node IPs, comma-separated (default: no workers)`,
+      `Kubernetes worker node hostnames or IPs (comma-separated, default: no worker nodes)`,
     valueType: 'VARIABLE' as const,
     // validate: notEmpty,
-    valueLabel: 'WORKER_NODES',
-    initial: process.env.WORKER_NODES || '',
+    valueLabel: 'KUBE_WORKER_NODES',
+    initial: process.env.KUBE_WORKER_NODES || '',
     scope: 'ENVIRONMENT' as const,
   },
   {

--- a/infrastructure/environments/questions.ts
+++ b/infrastructure/environments/questions.ts
@@ -205,7 +205,7 @@ export const infrastructureQuestions = [
     name: 'kubeClusterNodeCidr',
     type: 'text' as const,
     message:
-      `Cluster network CIDR (default: no restrictions)`,
+      `Network CIDR range for Kubernetes node-to-node communication (default: no restrictions)`,
     valueType: 'VARIABLE' as const,
     validate: validateCIDR,
     valueLabel: 'KUBE_CLUSTER_NODE_CIDR',

--- a/infrastructure/environments/questions.ts
+++ b/infrastructure/environments/questions.ts
@@ -141,7 +141,7 @@ export const infrastructureQuestions = [
     name: 'kubeAPIHost',
     type: 'text' as const,
     message: 
-      `Please enter host/IP to expose Kubernetes API endpoint, (default: Master first IP address):`,
+      `Kubernetes API endpoint (default: auto-detect)`,
     valueType: 'VARIABLE' as const,
     // validate: notEmpty,
     valueLabel: 'KUBE_API_HOST',
@@ -149,14 +149,36 @@ export const infrastructureQuestions = [
     scope: 'ENVIRONMENT' as const
   },
   {
+    name: 'kubeApiAllowedCidrs',
+    type: 'text' as const,
+    message:
+      `Allowed CIDRs for Kubernetes API access (default: unrestricted)`,
+    valueType: 'VARIABLE' as const,
+    // validate: notEmpty,
+    valueLabel: 'KUBE_API_ALLOWED_CIDRS',
+    initial: process.env.KUBE_API_ALLOWED_CIDRS || "0.0.0.0/0",
+    scope: 'ENVIRONMENT' as const,
+  },
+  {
     name: 'workerNodes',
     type: 'text' as const,
     message:
-      `Please enter Kubernetes workers hosts/IP addresses (comma-separated), (default: no workers):`,
+      `Kubernetes worker node IPs, comma-separated (default: no workers)`,
     valueType: 'VARIABLE' as const,
     // validate: notEmpty,
     valueLabel: 'WORKER_NODES',
-    initial: process.env.WORKER_NODES,
+    initial: process.env.WORKER_NODES || '',
+    scope: 'ENVIRONMENT' as const,
+  },
+  {
+    name: 'kubeClusterNodeCidr',
+    type: 'text' as const,
+    message:
+      `Cluster network CIDR (default: no restrictions)`,
+    valueType: 'VARIABLE' as const,
+    // validate: notEmpty,
+    valueLabel: 'KUBE_CLUSTER_NODE_CIDR',
+    initial: process.env.KUBE_CLUSTER_NODE_CIDR || "0.0.0.0/0",
     scope: 'ENVIRONMENT' as const,
   },
 ]

--- a/infrastructure/environments/setup-environment.ts
+++ b/infrastructure/environments/setup-environment.ts
@@ -424,8 +424,8 @@ ALL_QUESTIONS.push(
       infrastructureQuestions,
       existingValues
     )
-    const workerNodes = infrastructure.workerNodes
-      ? infrastructure.workerNodes.split(',').map((ip: string) => ip.trim()) : []
+    const kubeWorkerNodes = infrastructure.kubeWorkerNodes
+      ? infrastructure.kubeWorkerNodes.split(',').map((ip: string) => ip.trim()) : []
 
     log('\n', kleur.bold().underline('SSH Users'), '\n')
     const users = await manageUsers(`infrastructure/server-setup/inventory/${environment}.yml`)
@@ -1291,9 +1291,9 @@ ALL_QUESTIONS.push(
     generateInventory(
       environment,
       {
-        worker_nodes: workerNodes,
-        backup_host: backupHost || '',
+        kube_worker_nodes: kubeWorkerNodes,
         kube_api_host: infrastructure.kubeAPIHost || '',
+        backup_host: backupHost || '',
         users: users
       }
     )
@@ -1316,11 +1316,11 @@ ALL_QUESTIONS.push(
     )
     await updateWorkflowEnvironments();
 
-    let addon_message = workerNodes.length > 0 || configureBackup ? 
+    let addon_message = kubeWorkerNodes.length > 0 || configureBackup ? 
       "--------------------------------------------------------------------------------------------\n" +
       `\n➡️ ${kleur.bold().yellow('COPY the SSH public key from the master VM to your clipboard')}\n` +
       "--------------------------------------------------------------------------------------------\n" : ""
-    addon_message += workerNodes.length > 0 ?
+    addon_message += kubeWorkerNodes.length > 0 ?
       `➡️ ${kleur.bold().yellow('Run following command on Kubernetes worker VM to create provision user and setup SSH key:')}\n` +
       "\n" +
       "curl -sfL https://raw.githubusercontent.com/opencrvs/infrastructure/refs/heads/develop/scripts/bootstrap/opencrvs-bootstrap.sh -o opencrvs-bootstrap.sh && \\ \n" +

--- a/infrastructure/environments/swarm-to-k8s.ts
+++ b/infrastructure/environments/swarm-to-k8s.ts
@@ -66,15 +66,15 @@ import { createEnvironmentSecret, createEnvironmentVariable, getRepositoryId } f
     const master = dockerManagerFirst(data) || ''
     log(`  ✓ Kubernetes API Host (Docker Manager): ${master}`);
     const users = extractAndModifyUsers(data);
-    const worker_nodes = extractWorkerNodes(data);
-    log(`  ✓ Worker nodes: ${worker_nodes.join(', ')}`);
+    const kube_worker_nodes = extractWorkerNodes(data);
+    log(`  ✓ Worker nodes: ${kube_worker_nodes.join(', ')}`);
     const backup_host = extractBackupNode(data);
     log(`  ✓ Backup host: ${backup_host}`);
 
     generateInventory(
         environment,
         {
-            worker_nodes: worker_nodes,
+            kube_worker_nodes: kube_worker_nodes,
             users: users,
             backup_host: environment === 'production' ? backup_host : '',
             kube_api_host: master
@@ -141,7 +141,7 @@ import { createEnvironmentSecret, createEnvironmentVariable, getRepositoryId } f
         }
         const variablesToCreate = {
             BACKUP_HOST: backup_host,
-            WORKER_NODES: worker_nodes.join(','),
+            KUBE_WORKER_NODES: kube_worker_nodes.join(','),
         }
         for (const [secretName, secretValue] of Object.entries(secretsToCreate)) {
             try {

--- a/infrastructure/environments/templates.ts
+++ b/infrastructure/environments/templates.ts
@@ -123,7 +123,7 @@ export function generateInventory(env: string, values: Record<string, any>){
 
   const templateFile = fs.readFileSync(templatePath, "utf-8");
   const template = Handlebars.compile(templateFile);
-  values['single_node'] = (values['worker_nodes'].length > 0 || values['backup_host']) ? "false" : "true";
+  values['single_node'] = (values['kube_worker_nodes'].length > 0 || values['backup_host']) ? "false" : "true";
 
   const updated = template(values);
 

--- a/infrastructure/environments/templates/inventory/inventory.template.yml
+++ b/infrastructure/environments/templates/inventory/inventory.template.yml
@@ -76,13 +76,13 @@ all:
             traefik-role: ingress
             # By default all datastores are deployed to node with role data1
             role: data1
-  {{#if worker_nodes}}
+  {{#if kube_worker_nodes}}
     # Workers section is optional, for single node cluster feel free to remove this section
     # section can be added later
     # more workers can be added later as well
     workers:
       hosts:
-    {{#each worker_nodes as |host idx|}}
+    {{#each kube_worker_nodes as |host idx|}}
         worker{{idx}}:
           ansible_host: {{host}}
           labels:

--- a/infrastructure/server-setup/group_vars/all.yml
+++ b/infrastructure/server-setup/group_vars/all.yml
@@ -55,9 +55,9 @@ eviction_soft_nodefs: "20Gi"          # Minimum free space on root (/) filesyste
 eviction_soft_imagefs: "20Gi"         # Minimum free space for container images over time
 
 # CIDR containing Kubernetes nodes (used for UFW rules, default: no restrictions)
-cluster_node_cidr: "0.0.0.0/0"
+kube_cluster_node_cidr: "0.0.0.0/0"
 # CIDR(s) allowed to access Kubernetes API server, comma-separated (used for UFW rules, default: no restrictions)
-kubernetes_api_allowed_cidrs: "0.0.0.0/0"
+kube_api_allowed_cidrs: "0.0.0.0/0"
 
 # Container Network Interface plugin: Calico version
 calico_version: "v3.32.0"

--- a/infrastructure/server-setup/group_vars/all.yml
+++ b/infrastructure/server-setup/group_vars/all.yml
@@ -54,6 +54,10 @@ eviction_hard_imagefs: "10Gi"         # Minimum free space for container images
 eviction_soft_nodefs: "20Gi"          # Minimum free space on root (/) filesystem over time
 eviction_soft_imagefs: "20Gi"         # Minimum free space for container images over time
 
+# CIDR containing Kubernetes nodes (used for UFW rules, default: no restrictions)
+cluster_node_cidr: "0.0.0.0/0"
+# CIDR(s) allowed to access Kubernetes API server, comma-separated (used for UFW rules, default: no restrictions)
+kubernetes_api_allowed_cidrs: "0.0.0.0/0"
 
 # Container Network Interface plugin: Calico version
 calico_version: "v3.32.0"

--- a/infrastructure/server-setup/tasks/all/checks-k8s.yml
+++ b/infrastructure/server-setup/tasks/all/checks-k8s.yml
@@ -2,44 +2,44 @@
 - name: Check if Kubernetes cluster is initialized
   ansible.builtin.stat:
     path: /etc/kubernetes/admin.conf
-  register: k8s_is_installed
+  register: kube_is_installed
 
 - name: Pre-flight checks block
-  when: k8s_is_installed.stat.exists
+  when: kube_is_installed.stat.exists
   block:
     - name: Get current Kubernetes version
       ansible.builtin.shell: kubectl version | grep 'Server Version' | awk '{print $3}' | sed 's/v//'
-      register: current_k8s_version_raw
+      register: current_kube_version_raw
 
     - name: Get target Kubernetes version
       ansible.builtin.shell: echo {{ kubernetes_version }} | sed 's/v//'
-      register: target_k8s_version_raw
+      register: target_kube_version_raw
 
     - name: Set version facts
       ansible.builtin.set_fact:
-        current_k8s_version: "{{ current_k8s_version_raw.stdout }}"
-        k8s_target_version: "{{ target_k8s_version_raw.stdout }}"
+        current_kube_version: "{{ current_kube_version_raw.stdout }}"
+        kube_target_version: "{{ target_kube_version_raw.stdout }}"
 
     - name: Display current and target versions
       ansible.builtin.debug:
         msg: |
-          Current Kubernetes version: {{ current_k8s_version }}
-          Target Kubernetes version: {{ k8s_target_version }}
-          Configuration files exist: {{ k8s_is_installed.stat.exists }}
+          Current Kubernetes version: {{ current_kube_version }}
+          Target Kubernetes version: {{ kube_target_version }}
+          Configuration files exist: {{ kube_is_installed.stat.exists }}
 
     - name: Parse version numbers
       ansible.builtin.set_fact:
-        current_major: "{{ current_k8s_version.split('.')[0] }}"
-        current_minor: "{{ current_k8s_version.split('.')[1] }}"
-        target_major: "{{ k8s_target_version.split('.')[0] }}"
-        target_minor: "{{ k8s_target_version.split('.')[1] }}"
+        current_major: "{{ current_kube_version.split('.')[0] }}"
+        current_minor: "{{ current_kube_version.split('.')[1] }}"
+        target_major: "{{ kube_target_version.split('.')[0] }}"
+        target_minor: "{{ kube_target_version.split('.')[1] }}"
 
     - name: Check if downgrade attempt
       ansible.builtin.fail:
         msg: |
           ❌ Downgrade detected!
-          Current version: {{ current_k8s_version }}
-          Target version: {{ k8s_target_version }}
+          Current version: {{ current_kube_version }}
+          Target version: {{ kube_target_version }}
           Please downgrade manually using kubeadm!
       when: 
         - (target_major | int < current_major | int) or
@@ -49,8 +49,8 @@
       ansible.builtin.fail:
         msg: |
           ❌ Invalid upgrade path detected!
-          Current version: {{ current_k8s_version }}
-          Target version: {{ k8s_target_version }}
+          Current version: {{ current_kube_version }}
+          Target version: {{ kube_target_version }}
           
           You are trying to skip minor versions. Kubernetes must be upgraded sequentially.
           
@@ -101,7 +101,7 @@
 
     - name: Check for deprecated APIs
       ansible.builtin.shell: |
-        /tmp/pluto detect-all-in-cluster --target-versions k8s=v{{ k8s_target_version }} -o wide
+        /tmp/pluto detect-all-in-cluster --target-versions k8s=v{{ kube_target_version }} -o wide
       register: pluto_check
       changed_when: false
       failed_when: false
@@ -122,7 +122,7 @@
     - name: Fail if critical API deprecations found
       ansible.builtin.fail:
         msg: |
-          ❌ Critical API deprecations detected that will break in {{ k8s_target_version }}
+          ❌ Critical API deprecations detected that will break in {{ kube_target_version }}
           Please remediate before upgrading.
       when:
         - pluto_check.stdout is defined
@@ -171,7 +171,7 @@
           ====================================
           ✅ All pre-flight checks passed!
           ====================================
-          Current version: {{ current_k8s_version }}
-          Target version: {{ k8s_target_version }}
+          Current version: {{ current_kube_version }}
+          Target version: {{ kube_target_version }}
           
           Proceeding with upgrade...

--- a/infrastructure/server-setup/tasks/backups/crontab-rotate-backup.yml
+++ b/infrastructure/server-setup/tasks/backups/crontab-rotate-backup.yml
@@ -7,8 +7,8 @@
 - name: 'Setup backup rotation'
   cron:
     user: '{{ crontab_user }}'
-    name: 'rotate backups in {{ backup_server_user_home }}/{{ k8s_cluster_env }}'
+    name: 'rotate backups in {{ backup_server_user_home }}/{{ kube_cluster_env }}'
     minute: '0'
     hour: '0'
     # FIXME: We should have dedicated variable for backup
-    job: 'bash {{ backup_server_user_home }}/rotate_backups.sh --backup_dir={{ backup_server_user_home }}/{{ k8s_cluster_env }} --amount_to_keep={{ amount_of_backups_to_keep }} >> /var/log/opencrvs-rotate-backups.log 2>&1'
+    job: 'bash {{ backup_server_user_home }}/rotate_backups.sh --backup_dir={{ backup_server_user_home }}/{{ kube_cluster_env }} --amount_to_keep={{ amount_of_backups_to_keep }} >> /var/log/opencrvs-rotate-backups.log 2>&1'

--- a/infrastructure/server-setup/tasks/backups/install-pgbackrest.yml
+++ b/infrastructure/server-setup/tasks/backups/install-pgbackrest.yml
@@ -37,4 +37,4 @@
     # FIXME: Is there any smarter way to configure file per user?
     content: |
       [global]
-      repo1-path={{ backup_server_user_home }}/{{ k8s_cluster_env }}
+      repo1-path={{ backup_server_user_home }}/{{ kube_cluster_env }}

--- a/infrastructure/server-setup/tasks/k8s/init-master.yml
+++ b/infrastructure/server-setup/tasks/k8s/init-master.yml
@@ -2,10 +2,10 @@
 - name: Check if Kubernetes is already initialized
   stat:
     path: /etc/kubernetes/admin.conf
-  register: k8s_init_check
+  register: kube_init_check
 
 - name: Initialize Kubernetes cluster
-  when: not k8s_init_check.stat.exists
+  when: not kube_init_check.stat.exists
   shell: |
     sudo kubeadm init \
       --apiserver-advertise-address={{ kube_api_address | default(ansible_default_ipv4.address) }} \
@@ -60,6 +60,6 @@
     force: yes
 
 - name: Display initialization result
-  when: not k8s_init_check.stat.exists
+  when: not kube_init_check.stat.exists
   debug:
     msg: "{{ kubeadm_init_result.stdout_lines }}"

--- a/infrastructure/server-setup/tasks/k8s/label-nodes.yml
+++ b/infrastructure/server-setup/tasks/k8s/label-nodes.yml
@@ -1,6 +1,6 @@
 - name: Build list of labelable nodes
   ansible.builtin.set_fact:
-    k8s_nodes_to_label: >-
+    kube_nodes_to_label: >-
       {{
         (
           groups['master'] + (groups['workers'] | default([]))
@@ -20,5 +20,5 @@
     merge_type:
       - strategic-merge
       - merge
-  loop: "{{ k8s_nodes_to_label }}"
+  loop: "{{ kube_nodes_to_label }}"
   when: item.labels is defined

--- a/infrastructure/server-setup/tasks/k8s/self-hosted-runner.yml
+++ b/infrastructure/server-setup/tasks/k8s/self-hosted-runner.yml
@@ -47,6 +47,12 @@
 - name: Deploy opencrvs-infra-runner
   retries: 10
   delay: 60
+  vars:
+    base_labels:
+      - "self-hosted"
+      - "k8s"
+      - "{{ k8s_cluster_env }}"
+    extra_labels: "{{ self_hosted_runner_additional_labels | default('') | split(',') | reject('equalto','') | list }}"
   kubernetes.core.k8s:
     state: present
     definition:
@@ -62,7 +68,4 @@
             serviceAccountName: opencrvs-runner
             repository: "{{ repository }}"
             image: ghcr.io/opencrvs/opencrvs-github-runner:latest
-            labels:
-              - "self-hosted"
-              - "k8s"
-              - "{{ k8s_cluster_env }}"
+            labels: "{{ base_labels + extra_labels }}"

--- a/infrastructure/server-setup/tasks/k8s/self-hosted-runner.yml
+++ b/infrastructure/server-setup/tasks/k8s/self-hosted-runner.yml
@@ -15,7 +15,7 @@
         enabled: false
       authSecret:
         create: true
-        github_token: "{{ k8s_runner_token }}"
+        github_token: "{{ kube_runner_token }}"
 
 - name: Create ServiceAccount for opencrvs-runner
   kubernetes.core.k8s:
@@ -51,8 +51,8 @@
     base_labels:
       - "self-hosted"
       - "k8s"
-      - "{{ k8s_cluster_env }}"
-    extra_labels: "{{ self_hosted_runner_additional_labels | default('') | split(',') | reject('equalto','') | list }}"
+      - "{{ kube_cluster_env }}"
+    extra_labels: "{{ kube_self_hosted_runner_additional_labels | default('') | split(',') | reject('equalto','') | list }}"
   kubernetes.core.k8s:
     state: present
     definition:

--- a/infrastructure/server-setup/tasks/k8s/ufw.yml
+++ b/infrastructure/server-setup/tasks/k8s/ufw.yml
@@ -3,28 +3,61 @@
     name: ufw
     state: present
 
+- name: "Show UFW status before changes"
+  shell: ufw status numbered
+
+- name: Delete existing UFW rules managed by Ansible
+  shell: |
+    ufw status numbered \
+      | grep 'Managed by OpenCRVS Ansible' \
+      | grep -vE '\b(22|80|443)(/tcp|/udp)?\b' \
+      | tac \
+      | sed -n 's/^\[\s*\([0-9]\+\)\].*/\1/p' \
+      | while read rule; do
+          echo "Deleting UFW rule #$rule"
+          ufw --force delete "$rule"
+        done
+  changed_when: true
+
 - name: "Allow Traefik (ports 80, 443) only on master"
   ufw:
     rule: allow
     port: "{{ item }}"
     proto: tcp
-  loop:
-    # Http and HTTPS for Traefik (if using hostPort or nodePort)
-    - { port: 80, proto: "tcp" }
-    - { port: 443, proto: "tcp" }
-    # Calico Typha
-    - { port: 5473, proto: "tcp" }
+    comment: "Managed by OpenCRVS Ansible"
+  loop: [80, 443]
   when: "'master' in group_names"
 
+- name: "Allow Kubernetes API server access only from allowed CIDRs on master"
+  ufw:
+    rule: allow
+    port: "6443"
+    proto: tcp
+    from_ip: "{{ item }}"
+    comment: "Managed by OpenCRVS Ansible"
+  loop: >-
+    {{
+      kubernetes_api_allowed_cidrs.split(',')
+      | map('trim')
+      | list
+    }}
+  when: "'master' in group_names"
+
+- name: "Allow ssh connections"
+  ufw:
+    rule: allow
+    port: "22"
+    proto: tcp
+    comment: "Managed by OpenCRVS Ansible"
 # Kube and overlay ports for all nodes, adjust as needed
 - name: "Allow cluster communication ports"
   ufw:
     rule: allow
     port: "{{ item.port }}"
     proto: "{{ item.proto }}"
+    from_ip: "{{ cluster_node_cidr }}"
+    comment: "Managed by OpenCRVS Ansible"
   loop:
-    # Remote access
-    - { port: 22, proto: "tcp" }
     # Kubernetes API server (required by control plane & nodes)
     - { port: 6443, proto: "tcp" }
     # etcd API server (required by control plane only)
@@ -53,6 +86,7 @@
   community.general.ufw:
     rule: allow
     interface_in: "{{ item }}"
+    comment: "Managed by OpenCRVS Ansible"
   loop:
     - cali+
     - vxlan.calico

--- a/infrastructure/server-setup/tasks/k8s/ufw.yml
+++ b/infrastructure/server-setup/tasks/k8s/ufw.yml
@@ -37,7 +37,7 @@
     comment: "Managed by OpenCRVS Ansible"
   loop: >-
     {{
-      kubernetes_api_allowed_cidrs.split(',')
+      kube_api_allowed_cidrs.split(',')
       | map('trim')
       | list
     }}
@@ -55,7 +55,7 @@
     rule: allow
     port: "{{ item.port }}"
     proto: "{{ item.proto }}"
-    from_ip: "{{ cluster_node_cidr }}"
+    from_ip: "{{ kube_cluster_node_cidr }}"
     comment: "Managed by OpenCRVS Ansible"
   loop:
     # Kubernetes API server (required by control plane & nodes)

--- a/infrastructure/server-setup/tasks/k8s/upgrade-k8s-master.yml
+++ b/infrastructure/server-setup/tasks/k8s/upgrade-k8s-master.yml
@@ -5,22 +5,22 @@
 
 - name: Get current Kubernetes version
   ansible.builtin.shell: kubectl version | grep 'Server Version' | awk '{print $3}' | sed 's/v//'
-  register: current_k8s_version_raw
+  register: current_kube_version_raw
 
 - name: Set version facts
   ansible.builtin.set_fact:
     kubelet_version: "{{ kubelet_version_raw.stdout }}"
-    current_k8s_version: "{{ current_k8s_version_raw.stdout }}"
+    current_kube_version: "{{ current_kube_version_raw.stdout }}"
 
 - name: Determine if upgrade is needed
   ansible.builtin.set_fact:
-    upgrade_needed: "{{ current_k8s_version != kubelet_version }}"
+    upgrade_needed: "{{ current_kube_version != kubelet_version }}"
 
 - name: Display upgrade status
   ansible.builtin.debug:
     msg: |
       Kubelet version: {{ kubelet_version }}
-      Server version: {{ current_k8s_version }}
+      Server version: {{ current_kube_version }}
       Target version: {{ kubernetes_version }}
       Upgrade needed: {{ upgrade_needed }}
 

--- a/infrastructure/server-setup/tasks/k8s/user-kubeconfig.yml
+++ b/infrastructure/server-setup/tasks/k8s/user-kubeconfig.yml
@@ -40,7 +40,7 @@
   shell: |
     env
     cd /root
-    /opt/opencrvs/scripts/add-k8s-user.sh {{ item.name }}-{{ k8s_cluster_env }}
+    /opt/opencrvs/scripts/add-k8s-user.sh {{ item.name }}-{{ kube_cluster_env }}
   with_items: '{{ users }}'
   when: item.state == 'present'
 
@@ -60,5 +60,5 @@
   when: item.state == 'present'
   shell: |
     rm -rf /home/{{ item.name }}/.kube
-    mv /root/user-kubeconfigs/{{ item.name }}-{{ k8s_cluster_env }} /home/{{ item.name }}/.kube
+    mv /root/user-kubeconfigs/{{ item.name }}-{{ kube_cluster_env }} /home/{{ item.name }}/.kube
     chown -R {{ item.name }}:{{ item.name }} /home/{{ item.name }}/.kube

--- a/infrastructure/server-setup/templates/motd.j2
+++ b/infrastructure/server-setup/templates/motd.j2
@@ -10,7 +10,7 @@ Welcome to the system!
         |_|         
 
 ==================================
-🌎 This is a {{ k8s_cluster_env }} environment. All logins and commands are audited.
+🌎 This is a {{ kube_cluster_env }} environment. All logins and commands are audited.
 🖥️  If you would like to connect to cluster from your local laptop, transfer ~/.kube directory to your laptop.
 💡 Type 'k8s-help' for Kubernetes command hints and shortcuts.
 ==================================


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/11790

Related documentation PR: https://app.gitbook.com/o/zub8C4BetmW3a9Bj4Cd4/s/TIJguU5Pzi7HeHrkXa4I/~/edit/~/changes/137/technical/guides/installation/deploy-set-up-a-server-hosted-environment/create-a-github-environment

Goal of this issue is to make Kubernetes configuration questions more transparent for end users

## Testing

### Non-restricted

Kubernetes section:
<img width="748" height="122" alt="image" src="https://github.com/user-attachments/assets/433964c1-7a54-4357-a47c-7f80e2f27ce1" />

Propagate new values:
<img width="587" height="70" alt="image" src="https://github.com/user-attachments/assets/503beb7e-070b-4fb2-8ca6-338e836fa803" />

Variables propagated to GitHub:
<img width="862" height="158" alt="image" src="https://github.com/user-attachments/assets/7eee2eb2-1a4f-472f-ae64-6d1ebdf45f7b" />

Execution:
<img width="641" height="717" alt="image" src="https://github.com/user-attachments/assets/ed2d2091-ed7e-4303-addc-a23831d70e38" />


Firewall status after deployment with no-restriction:
<img width="1655" height="877" alt="image" src="https://github.com/user-attachments/assets/f0e6d359-d353-4c4b-9429-f486b71d277e" />



### Restricted

Kubernetes section:
<img width="790" height="145" alt="image" src="https://github.com/user-attachments/assets/f73a5228-933b-4c85-9ce8-84a8f71b5ec6" />

Propagate changes:
<img width="545" height="64" alt="image" src="https://github.com/user-attachments/assets/9f9ee02f-cf90-4f80-af1f-064ed91c34d1" />

Variables propagated to GitHub:
<img width="850" height="161" alt="image" src="https://github.com/user-attachments/assets/a8fbd4d8-8d5e-4817-aab5-8672767ea3ad" />

Firewall status after deployment with no-restriction:
<img width="808" height="473" alt="image" src="https://github.com/user-attachments/assets/7104a574-054f-4614-8bf8-52e4c10120d9" />


## Other fixes applied

- Self-hosted runner additional labels: By default infrastructure environment name should always match with Application environment name and self-hosted k8s runners are limited to deploy only on matching environments. This fix will allow to define common label for k8s self-hosted runner and deploy multiple OpenCRVS instances within the same cluster. Very similar configuration works on e2e environment in hardcoded manner: https://github.com/opencrvs/e2e/actions/runs/21663263203/workflow#L54
- Added firewall options to harden incoming connections to OpenCRVS
