### PR TITLE
fix: Revisited unattended upgrades policy

### DIFF
--- a/infrastructure/server-setup/tasks/all/updates.yml
+++ b/infrastructure/server-setup/tasks/all/updates.yml
@@ -16,6 +16,11 @@
   apt:
     autoclean: yes
 
+- name: Remove legacy OpenCRVS unattended-upgrades config
+  ansible.builtin.file:
+    path: /etc/apt/apt.conf.d/50unattended-upgrades
+    state: absent
+
 - name: Configure Unattended Upgrades
   ansible.builtin.copy:
     dest: /etc/apt/apt.conf.d/99-opencrvs-unattended-upgrades
@@ -26,10 +31,11 @@
           "${distro_id}ESMApps:${distro_codename}-apps-security";
           "${distro_id}ESM:${distro_codename}-infra-security";
       };
-      // Kubernetes packages source pkgs.k8s.io is not enabled as part of Allowed-Origins
-      // OpenCRVS explicitly disables unattended upgrades for Kubernetes
-      // since some cloud providers (e.g. Azure) have Kubernetes packages in their repositories
-      // Use GitHub provision action to upgrade Kubernetes nodes
+      // Kubernetes packages from pkgs.k8s.io are not included in Allowed-Origins.
+      // OpenCRVS explicitly blocks automatic Kubernetes package upgrades because
+      // some cloud providers, e.g. Azure, may expose Kubernetes packages through
+      // repositories that could otherwise match unattended-upgrades origins.
+      // Use GitHub provision action to upgrade Kubernetes nodes.
       Unattended-Upgrade::Package-Blacklist {
               "kubeadm";
               "kubelet";

--- a/infrastructure/server-setup/tasks/all/updates.yml
+++ b/infrastructure/server-setup/tasks/all/updates.yml
@@ -18,16 +18,28 @@
 
 - name: Configure Unattended Upgrades
   ansible.builtin.copy:
-    dest: /etc/apt/apt.conf.d/50unattended-upgrades
+    dest: /etc/apt/apt.conf.d/99-opencrvs-unattended-upgrades
     content: |
-      Unattended-Upgrade::Package-Blacklist {};
-      Unattended-Upgrade::DevRelease "auto";
-      Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
-      Unattended-Upgrade::Remove-New-Unused-Dependencies "true";
-      Unattended-Upgrade::Remove-Unused-Dependencies "true";
       Unattended-Upgrade::Allowed-Origins {
+          "${distro_id}:${distro_codename}";
           "${distro_id}:${distro_codename}-security";
+          "${distro_id}ESMApps:${distro_codename}-apps-security";
+          "${distro_id}ESM:${distro_codename}-infra-security";
       };
+      // Kubernetes packages source pkgs.k8s.io is not enabled as part of Allowed-Origins
+      // OpenCRVS explicitly disables unattended upgrades for Kubernetes
+      // since some cloud providers (e.g. Azure) have Kubernetes packages in their repositories
+      // Use GitHub provision action to upgrade Kubernetes nodes
+      Unattended-Upgrade::Package-Blacklist {
+              "kubeadm";
+              "kubelet";
+              "kubectl";
+              "kubernetes-cni";
+      };
+      Unattended-Upgrade::Automatic-Reboot "false";
+      Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+      Unattended-Upgrade::Remove-Unused-Dependencies "true";
+      Unattended-Upgrade::Remove-New-Unused-Dependencies "true";
     owner: root
     group: root
     mode: '0644'


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/7553

Related documentation PR: https://documentation.opencrvs.org/v2.0/~/changes/257/technical/guides/installation/advanced-topics/ubuntu-unattended-upgrades

Key changes:
1. Added repositories enabled by default 
2. Explicitly black-listed Kubernetes packages, see comment in ansible task and lessons learned from deployment on Azure VMs (cc @euanmillar)
3. Renamed file from default /etc/apt/apt.conf.d/50unattended-upgrades to /etc/apt/apt.conf.d/99-opencrvs-unattended-upgrades. By this change issues with Ubuntu upgrade will be mitigated, see upgrade notes between 22.04 and 24.04 at https://github.com/opencrvs/documentation/blob/master/developer-manual/servers/upgrading-eol-ubuntu.md#list-of-configuration-files-effected-by-upgrade

## Testing

<img width="675" height="68" alt="image" src="https://github.com/user-attachments/assets/88085bca-76df-41d5-bcd0-1dbec6b3b00a" />

