### PR TITLE
fix: Security adjustments

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -17,17 +17,16 @@ on:
         type: choice
         options:
           - all
+          - users
+          - k8s
           - checks
           - updates
-          - users
           - backup
           - application
           - tools
           - fail2ban
           - data-partition
           - decrypt-on-boot
-          - containerd-setup
-          - k8s
           - system-preparation
 jobs:
   approve:
@@ -76,8 +75,8 @@ jobs:
           alert_email: ${{ secrets.ALERT_EMAIL }}
           backup_host_public_key: ${{ secrets.BACKUP_HOST_PUBLIC_KEY }}
           kube_cluster_env: ${{ inputs.environment }}
+          kube_api_host: ${{ vars.KUBE_API_HOST }}
           kube_api_allowed_cidrs: ${{ vars.KUBE_API_ALLOWED_CIDRS }}
-          kube_cluster_node_cidr: ${{ vars.KUBE_CLUSTER_NODE_CIDR }}
           kube_runner_token: ${{ secrets.GH_TOKEN }}
           kube_self_hosted_runner_additional_labels: ${{ vars.KUBE_SELF_HOSTED_RUNNER_ADDITIONAL_LABELS }}
       - name: checkout repository

--- a/infrastructure/environments/questions.ts
+++ b/infrastructure/environments/questions.ts
@@ -187,7 +187,7 @@ export const infrastructureQuestions = [
     valueType: 'VARIABLE' as const,
     validate: validateCIDRs,
     valueLabel: 'KUBE_API_ALLOWED_CIDRS',
-    initial: process.env.KUBE_API_ALLOWED_CIDRS || "0.0.0.0/0",
+    initial: process.env.KUBE_API_ALLOWED_CIDRS || "",
     scope: 'ENVIRONMENT' as const,
   },
   {
@@ -199,17 +199,6 @@ export const infrastructureQuestions = [
     // validate: notEmpty,
     valueLabel: 'KUBE_WORKER_NODES',
     initial: process.env.KUBE_WORKER_NODES || '',
-    scope: 'ENVIRONMENT' as const,
-  },
-  {
-    name: 'kubeClusterNodeCidr',
-    type: 'text' as const,
-    message:
-      `Network CIDR range for Kubernetes node-to-node communication (default: no restrictions)`,
-    valueType: 'VARIABLE' as const,
-    validate: validateCIDR,
-    valueLabel: 'KUBE_CLUSTER_NODE_CIDR',
-    initial: process.env.KUBE_CLUSTER_NODE_CIDR || "0.0.0.0/0",
     scope: 'ENVIRONMENT' as const,
   },
 ]

--- a/infrastructure/environments/templates/inventory/inventory.template.yml
+++ b/infrastructure/environments/templates/inventory/inventory.template.yml
@@ -15,7 +15,7 @@ all:
     # - If you would like to run kubectl commands from the remote server, leave this field empty
     # kube_api_endpoint: ''
 
-    # IMPORTANT: If master VM has multiple ethernet interfaces, put private IP address at kube_api_address
+    # IMPORTANT: If master VM has multiple ethernet interfaces, put private IP address at kube_api_host
     # kube_api_host: 10.10.10.10
     kube_api_host: {{kube_api_host}}
 

--- a/infrastructure/environments/templates/inventory/production.example.yml
+++ b/infrastructure/environments/templates/inventory/production.example.yml
@@ -14,12 +14,9 @@ all:
     # - If your server is exposed (not recommeded), use public IP address
     # - If you would like to run kubectl commands from the remote server, leave this field empty
 
-    # IMPORTANT: If master VM has multiple ethernet interfaces, put private IP address at kube_api_address
+    # IMPORTANT: If master VM has multiple ethernet interfaces, put private IP address at kube_api_host
     # kube_api_host: 10.10.10.10
     kube_api_host: ''
-
-    # IMPORTANT: If master VM has multiple ethernet interfaces, put private IP address at kube_api_address
-    # kube_api_address: 10.10.10.10
 
     # Default ansible provision user, keep as is
     ansible_user: provision

--- a/infrastructure/server-setup/group_vars/all.yml
+++ b/infrastructure/server-setup/group_vars/all.yml
@@ -69,8 +69,8 @@ cluster_communication_ports:
     - { port: 4789, proto: "udp" }   # VXLAN (Calico; verify if needed)
     - { port: 179, proto: "tcp" }    # BGP (Calico)
     - { port: 179, proto: "udp" }    # BGP (Calico)
-# CIDR(s) allowed to access Kubernetes API server, comma-separated (used for UFW rules, default: no restrictions)
-kube_api_allowed_cidrs: "0.0.0.0/0"
+# CIDR(s) allowed to access Kubernetes API server, comma-separated (used for UFW rules, default: cluster nodes only)
+kube_api_allowed_cidrs: ""
 
 # Container Network Interface plugin: Calico version
 calico_version: "v3.32.0"

--- a/infrastructure/server-setup/group_vars/all.yml
+++ b/infrastructure/server-setup/group_vars/all.yml
@@ -69,6 +69,7 @@ cluster_communication_ports:
     - { port: 4789, proto: "udp" }   # VXLAN (Calico; verify if needed)
     - { port: 179, proto: "tcp" }    # BGP (Calico)
     - { port: 179, proto: "udp" }    # BGP (Calico)
+
 # CIDR(s) allowed to access Kubernetes API server, comma-separated (used for UFW rules, default: cluster nodes only)
 kube_api_allowed_cidrs: ""
 

--- a/infrastructure/server-setup/group_vars/all.yml
+++ b/infrastructure/server-setup/group_vars/all.yml
@@ -54,8 +54,21 @@ eviction_hard_imagefs: "10Gi"         # Minimum free space for container images
 eviction_soft_nodefs: "20Gi"          # Minimum free space on root (/) filesystem over time
 eviction_soft_imagefs: "20Gi"         # Minimum free space for container images over time
 
-# CIDR containing Kubernetes nodes (used for UFW rules, default: no restrictions)
-kube_cluster_node_cidr: "0.0.0.0/0"
+# Ports required for Kubernetes cluster node-to-node communication (used for firewall/UFW rules)
+cluster_communication_ports:
+    # Kubelet API (required for all nodes)
+    - { port: 10250, proto: "tcp" }
+    # kube-scheduler (control plane only)
+    - { port: 10251, proto: "tcp" }
+    # kube-controller-manager (control plane only)
+    - { port: 10252, proto: "tcp" }
+    # Overlay network (Calico/Weave/Flannel, if used—verify your CNI and usage)
+    - { port: 7946, proto: "tcp" }   # Used by some CNIs (e.g., Flannel, Weave)
+    - { port: 7946, proto: "udp" }   # Used by some CNIs (e.g., Flannel, Weave)
+    - { port: 8472, proto: "udp" }   # VXLAN (Flannel/Calico; verify if needed)
+    - { port: 4789, proto: "udp" }   # VXLAN (Calico; verify if needed)
+    - { port: 179, proto: "tcp" }    # BGP (Calico)
+    - { port: 179, proto: "udp" }    # BGP (Calico)
 # CIDR(s) allowed to access Kubernetes API server, comma-separated (used for UFW rules, default: no restrictions)
 kube_api_allowed_cidrs: "0.0.0.0/0"
 

--- a/infrastructure/server-setup/k8s.yml
+++ b/infrastructure/server-setup/k8s.yml
@@ -50,17 +50,36 @@
         file: tasks/k8s/install-containerd.yml
         apply:
           tags:
-            - containerd-setup
+            - k8s
       tags:
-        - containerd-setup
+        - k8s
     - name: Include Kubernetes installation tasks
       include_tasks:
         file: tasks/k8s/install-kubernetes.yml
         apply:
           tags:
-            - kubernetes-installation
+            - k8s
       tags:
-          - kubernetes-installation
+          - k8s
+    - name: Include Kubernetes private IP configuration tasks
+      include_tasks:
+        file: tasks/k8s/configure-private-ip.yml
+        apply:
+          tags:
+            - k8s
+      tags:
+          - k8s
+
+- name: Temporary UFW configuration for Kubernetes installation
+  hosts: master
+  become: yes
+  tags: k8s
+  tasks:
+    - name: "Setup UFW with allow by default"
+      ufw:
+        state: enabled
+        default: allow
+        direction: incoming
 
 - name: Kubernetes Master
   hosts: master

--- a/infrastructure/server-setup/tasks/k8s/configure-private-ip.yml
+++ b/infrastructure/server-setup/tasks/k8s/configure-private-ip.yml
@@ -1,0 +1,32 @@
+---
+- name: Determine kubelet node IP
+  set_fact:
+    kubelet_node_ip: >-
+      {{
+        (
+          kube_api_host
+          if inventory_hostname in groups['master']
+          else ansible_host
+        ) | default(ansible_default_ipv4.address, true)
+      }}
+
+- name: Show Kubelet node IP
+  debug:
+    var: kubelet_node_ip
+
+- name: Configure kubelet node IP
+  become: yes
+  copy:
+    dest: /etc/default/kubelet
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      KUBELET_EXTRA_ARGS="--node-ip={{ kubelet_node_ip }}"
+
+- name: Restart kubelet
+  become: yes
+  systemd:
+    name: kubelet
+    daemon_reload: true
+    state: restarted

--- a/infrastructure/server-setup/tasks/k8s/configure-private-ip.yml
+++ b/infrastructure/server-setup/tasks/k8s/configure-private-ip.yml
@@ -23,6 +23,7 @@
     mode: "0644"
     content: |
       KUBELET_EXTRA_ARGS="--node-ip={{ kubelet_node_ip }}"
+  register: kubelet_default_file
 
 - name: Restart kubelet
   become: yes
@@ -30,3 +31,4 @@
     name: kubelet
     daemon_reload: true
     state: restarted
+  when: kubelet_default_file.changed

--- a/infrastructure/server-setup/tasks/k8s/init-master.yml
+++ b/infrastructure/server-setup/tasks/k8s/init-master.yml
@@ -8,9 +8,9 @@
   when: not kube_init_check.stat.exists
   shell: |
     sudo kubeadm init \
-      --apiserver-advertise-address={{ kube_api_address | default(ansible_default_ipv4.address) }} \
+      --apiserver-advertise-address={{ kube_api_host | default(ansible_default_ipv4.address) }} \
       --pod-network-cidr={{ pod_network_cidr }} \
-      --control-plane-endpoint={{ kube_api_address | default(ansible_default_ipv4.address) }}
+      --control-plane-endpoint={{ kube_api_host | default(ansible_default_ipv4.address) }}
   register: kubeadm_init_result
 
 - name: Create .kube directory for provision user

--- a/infrastructure/server-setup/tasks/k8s/init-master.yml
+++ b/infrastructure/server-setup/tasks/k8s/init-master.yml
@@ -8,9 +8,9 @@
   when: not kube_init_check.stat.exists
   shell: |
     sudo kubeadm init \
-      --apiserver-advertise-address={{ kube_api_host | default(ansible_default_ipv4.address) }} \
+      --apiserver-advertise-address={{ kube_api_host | default(ansible_default_ipv4.address, true) }} \
       --pod-network-cidr={{ pod_network_cidr }} \
-      --control-plane-endpoint={{ kube_api_host | default(ansible_default_ipv4.address) }}
+      --control-plane-endpoint={{ kube_api_host | default(ansible_default_ipv4.address, true) }}
   register: kubeadm_init_result
 
 - name: Create .kube directory for provision user

--- a/infrastructure/server-setup/tasks/k8s/ufw.yml
+++ b/infrastructure/server-setup/tasks/k8s/ufw.yml
@@ -28,58 +28,82 @@
   loop: [80, 443]
   when: "'master' in group_names"
 
-- name: "Allow Kubernetes API server access only from allowed CIDRs on master"
-  ufw:
-    rule: allow
-    port: "6443"
-    proto: tcp
-    from_ip: "{{ item }}"
-    comment: "Managed by OpenCRVS Ansible"
-  loop: >-
-    {{
-      kube_api_allowed_cidrs.split(',')
-      | map('trim')
-      | list
-    }}
-  when: "'master' in group_names"
-
 - name: "Allow ssh connections"
   ufw:
     rule: allow
     port: "22"
     proto: tcp
     comment: "Managed by OpenCRVS Ansible"
+
+- name: Get Kubernetes nodes from control plane
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Node
+    kubeconfig: /home/{{ ansible_user }}/.kube/config
+  register: k8s_nodes
+  when: "'master' in group_names"
+
+- name: Build cluster node IP list
+  set_fact:
+    cluster_node_ips: >-
+      {{
+        k8s_nodes.resources
+        | map(attribute='status.addresses')
+        | map('selectattr', 'type', 'equalto', 'InternalIP')
+        | map('first')
+        | map(attribute='address')
+        | list
+      }}
+  when: "'master' in group_names"
+
+- name: Show cluster node IPs
+  debug:
+    var: cluster_node_ips
+  when: "'master' in group_names"
+
+- name: Build Kubernetes API allowed CIDRs
+  set_fact:
+    kubernetes_api_allowed_sources: >-
+      {{
+        (
+          cluster_node_ips
+          | map('regex_replace', '$', '/32')
+          | list
+        )
+        +
+        (
+          kube_api_allowed_cidrs | default('') | split(',')
+          | map('trim')
+          | reject('equalto', '')
+          | list
+        )
+      }}
+  when: "'master' in group_names"
+
+- name: Allow Kubernetes API server access
+  ufw:
+    rule: allow
+    port: "6443"
+    proto: tcp
+    from_ip: "{{ item }}"
+    comment: "Managed by OpenCRVS Ansible"
+  loop: "{{ kubernetes_api_allowed_sources }}"
+  when: "'master' in group_names"
+
 # Kube and overlay ports for all nodes, adjust as needed
 - name: "Allow cluster communication ports"
   ufw:
     rule: allow
-    port: "{{ item.port }}"
-    proto: "{{ item.proto }}"
-    from_ip: "{{ kube_cluster_node_cidr }}"
+    port: "{{ item.0.port }}"
+    proto: "{{ item.0.proto }}"
+    from_ip: "{{ item.1 }}/32"
     comment: "Managed by OpenCRVS Ansible"
-  loop:
-    # Kubernetes API server (required by control plane & nodes)
-    - { port: 6443, proto: "tcp" }
-    # etcd API server (required by control plane only)
-    - { port: 2379, proto: "tcp" } # etcd client API
-    - { port: 2380, proto: "tcp" } # etcd peer communication
-    # Kubelet API (required for all nodes)
-    - { port: 10250, proto: "tcp" }
-    # kube-scheduler (control plane only)
-    - { port: 10251, proto: "tcp" }
-    # kube-controller-manager (control plane only)
-    - { port: 10252, proto: "tcp" }
-    # Overlay network (Calico/Weave/Flannel, if used—verify your CNI and usage)
-    - { port: 7946, proto: "tcp" }   # Used by some CNIs (e.g., Flannel, Weave)
-    - { port: 7946, proto: "udp" }   # Used by some CNIs (e.g., Flannel, Weave)
-    - { port: 8472, proto: "udp" }   # VXLAN (Flannel/Calico; verify if needed)
-    - { port: 4789, proto: "udp" }   # VXLAN (Calico; verify if needed)
-    - { port: 179, proto: "tcp" }    # BGP (Calico)
-    - { port: 179, proto: "udp" }    # BGP (Calico)
-    # Expose traefik on node port
-    # Rules are required for internet facing load balancer (if exists)
-    - { port: 30080, proto: "tcp" }  # NodePort HTTP
-    - { port: 30443, proto: "tcp" }  # NodePort HTTPS
+  loop: >-
+    {{
+      cluster_communication_ports
+      | product(hostvars[groups['master'][0]].cluster_node_ips)
+      | list
+    }}
   ignore_errors: yes
 
 - name: "Allow traffic on Calico interfaces"


### PR DESCRIPTION
## Description

### Block etcd from access outside of the master node

etcd is listening on loopback and default ethernet*. Kubernetes API server talks to etcd over loopback. Second network interface is needed only for communication with other etcd's (cluster mode). OpenCRVS does support single master deployment only and there is no need to keep etcd ports open on default ethernet adapter.


( * ) - default ethernet adapter is always same as Kubernetes API host (KUBE_API_HOST)

### Block Kubernetes API server access

By default access to Kubernetes API server is allowed from Kubernetes cluster nodes and approved admin/operator networks.


### Drop KUBE_CLUSTER_NODE_CIDR variable

KUBE_CLUSTER_NODE_CIDR was introduced as part of PR https://github.com/opencrvs/infrastructure/pull/323

Propose of this variable was to allow operator define subnet for Kubernetes worker nodes.
Property is now taken from Kubernetes API (`kubectl get nodes`) instead, see `Get Kubernetes nodes from control plane` ansible task


## Testing

Infrastructure for testing:

- tmp-kube01: 135.181.110.201 / 10.1.0.2
- tmp-kube02: 62.238.42.237 / 10.1.0.3
- tmp-kube03: 157.180.44.38 / 10.1.0.4

Test scenarios:
- Deployment on new servers:
  - tmp-kube01 (master)
  - tmp-kube02 (worker)
  - KUBE_API_HOST not set
  - KUBE_API_ALLOWED_CIDRS not set
- Add new node to the cluster: Update existing environment
  - tmp-kube01 (master)
  - tmp-kube02 (worker)
  - tmp-kube03 (worker)
  - KUBE_API_HOST not set
  - KUBE_API_ALLOWED_CIDRS not set
- Deploy cluster on private subnet
  - tmp-kube01 (master)
  - tmp-kube02 (worker)
  - KUBE_API_HOST set to 10.1.0.2
  - KUBE_API_ALLOWED_CIDRS not set
- Update cluster with approved networks on private subnet
  - tmp-kube01 (master)
  - tmp-kube02 (worker)
  - tmp-kube03 (worker)
  - KUBE_API_HOST set to 10.1.0.2
  - KUBE_API_ALLOWED_CIDRS set to 176.X.X.X (my public ip)

Test were performed on following repo: https://github.com/adskyiproger/opencrvs-infrastructure/tree/fix-fw-rules

To reduce configuration time, snapshots were created:
<img width="1080" height="408" alt="image" src="https://github.com/user-attachments/assets/0d588639-7791-418e-b0aa-6d1268a4bf4b" />

### Deployment on new servers

Configuration:
  - tmp-kube01 (master)
  - tmp-kube02 (worker)
  - KUBE_API_HOST not set
  - KUBE_API_ALLOWED_CIDRS not set

Provision workflow: ✅ https://github.com/adskyiproger/opencrvs-infrastructure/actions/runs/27610681084

Firewall state:
<img width="894" height="560" alt="image" src="https://github.com/user-attachments/assets/0d45f325-be68-446e-844a-3128b17f1d7e" />

Nodes:

Since KUBE_API_HOST was not, Kubernetes use first available ethernet as advertise IP.
<img width="1236" height="89" alt="image" src="https://github.com/user-attachments/assets/a383755e-2a72-4f6c-8c22-91d8777a7598" />



### Add new node to the cluster: Update existing environment

Configuration:
  - tmp-kube01 (master)
  - tmp-kube02 (worker)
  - tmp-kube03 (worker)
  - KUBE_API_HOST not set
  - KUBE_API_ALLOWED_CIDRS not set

Provision workflow: ✅ https://github.com/adskyiproger/opencrvs-infrastructure/actions/runs/27611734601/job/81637583208

<img width="1212" height="94" alt="image" src="https://github.com/user-attachments/assets/69aca019-f748-4fa3-8897-6d88620c8634" />

### Deploy cluster on private subnet

Configuration:
  - tmp-kube01 (master)
  - tmp-kube02 (worker)
  - KUBE_API_HOST set to 10.1.0.2
  - KUBE_API_ALLOWED_CIDRS not set

Provision workflow: ✅ https://github.com/adskyiproger/opencrvs-infrastructure/actions/runs/27618236712/job/81659661361

Environment init script was re-run and private KUBE_API_HOST was provided:
<img width="739" height="135" alt="image" src="https://github.com/user-attachments/assets/b104e056-8e24-45c1-b4ec-25ca36801d84" />

Private IP was identified properly:
- `KUBE_API_HOST` value for master node
- `ansible_host` for workers

<img width="773" height="149" alt="image" src="https://github.com/user-attachments/assets/dece9461-6f0b-4614-9552-6146d0ed268d" />

Firewall status after provision:
<img width="880" height="572" alt="image" src="https://github.com/user-attachments/assets/62a8d18c-8015-4023-b458-c85475b424e7" />

Nodes:
<img width="1158" height="72" alt="image" src="https://github.com/user-attachments/assets/50e7c18d-a50f-4d02-b4bd-0803114d986c" />


### Update cluster with approved networks on private subnet

Configuration:
  - tmp-kube01 (master)
  - tmp-kube02 (worker)
  - tmp-kube03 (worker)
  - KUBE_API_HOST set to 10.1.0.2
  - KUBE_API_ALLOWED_CIDRS set to 176.X.X.X (my public ip)

Provision workflow: ✅  https://github.com/adskyiproger/opencrvs-infrastructure/actions/runs/27619020206/job/81662478578

Environment init was reconfigured:
<img width="944" height="139" alt="image" src="https://github.com/user-attachments/assets/74542902-8adb-4b4b-9ec9-7013425edc2d" />

Firewall:

NOTE: Additional run due to small bug which I fixes later: https://github.com/adskyiproger/opencrvs-infrastructure/actions/runs/27620013805/job/81666085518

<img width="803" height="697" alt="image" src="https://github.com/user-attachments/assets/ed8d6be1-83dd-40b6-89ac-8b8d0ebe923b" />


Nodes:
<img width="1165" height="97" alt="image" src="https://github.com/user-attachments/assets/d64ec43b-5f39-4923-ac5e-fc57b8bf3079" />
