### PR TITLE
Install correct yq and set label for k8s

### DIFF
--- a/.github/workflows/github-to-k8s-sync-env.yml
+++ b/.github/workflows/github-to-k8s-sync-env.yml
@@ -279,6 +279,15 @@ jobs:
             echo "ℹ️  Dockerhub credentials not provided, skipping Docker Registry Secret creation for $DOCKERHUB_SECRET_NAME"
           fi
 
+      
+      - name: Install yq v4
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          /usr/local/bin/yq --version
+          which yq
+          type -a yq
+          yq --version
       - name: Apply secrets to Kubernetes
         run: |
           echo "✅ Generated manifests:"

--- a/scripts/bootstrap/node-runner.sh
+++ b/scripts/bootstrap/node-runner.sh
@@ -69,7 +69,7 @@ RUNNER_DIR=${RUNNER_DIR:-"/opt/github-runner"}
 # Runner name
 [[ -z "${RUNNER_NAME:-}" ]] && RUNNER_NAME="$(hostname)-runner"
 # Runner labels
-LABELS="self-hosted,linux,node,${ENV}"
+LABELS="self-hosted,linux,node,k8s,${ENV}"
 # Runner user and group
 RUNAS_USER="${RUNAS_USER:-provision}"
 RUNAS_GROUP="${RUNAS_GROUP:-provision}"


### PR DESCRIPTION
Sync GitHub env to Kuberentes was failing ...

1. The runner needed k8s label
2. can't open '.metadata.namespace': [Errno 2] No such file or directory: '.metadata.namespace (Solution was to install yq before applying secrets)