### PR TITLE
fix: Always restart self-hosted runner on k8s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 2.0.1 Release
+
+### Bug fixes
+
+- Always restart the Kubernetes self-hosted runner during deployment to ensure the latest runner image and configuration changes are applied. [#332](https://github.com/opencrvs/infrastructure/pull/332)

--- a/infrastructure/server-setup/tasks/k8s/self-hosted-runner.yml
+++ b/infrastructure/server-setup/tasks/k8s/self-hosted-runner.yml
@@ -16,6 +16,8 @@
       authSecret:
         create: true
         github_token: "{{ kube_runner_token }}"
+      podAnnotations:
+        opencrvs.org/lastdeploy-timestamp: "{{ ansible_date_time.epoch }}"
 
 - name: Create ServiceAccount for opencrvs-runner
   kubernetes.core.k8s:


### PR DESCRIPTION
# Description

This PR ensures the GitHub Actions runner is restarted on every deployment by adding a changing annotation to the RunnerDeployment pod template. This guarantees that the latest runner image and configuration (secrets) are applied even when no other manifest changes are detected.

# Testing

Tests were performed on SPC repo:

<img width="664" height="124" alt="image" src="https://github.com/user-attachments/assets/b7fca837-357f-495c-9b16-80ee7132cd8c" />

```
k describe po
```
<img width="987" height="324" alt="image" src="https://github.com/user-attachments/assets/631e73a4-c549-44a6-90b9-5b695736d300" />
